### PR TITLE
Set the host and port in psql_csv_run to work in multicluster environment

### DIFF
--- a/wal_e/cmd.py
+++ b/wal_e/cmd.py
@@ -42,7 +42,7 @@ logger = log_help.WalELogger('wal_e.main', level=logging.INFO)
 
 
 def external_program_check(
-    to_check=frozenset([PSQL_BIN, LZOP_BIN, PV_BIN])):
+    to_check=frozenset([PSQL_BIN, LZOP_BIN, PV_BIN]), data_directory=None):
     """
     Validates the existence and basic working-ness of other programs
 
@@ -72,7 +72,7 @@ def external_program_check(
         for program in to_check:
             try:
                 if program is PSQL_BIN:
-                    psql_csv_run('SELECT 1', error_handler=psql_err_handler)
+                    psql_csv_run('SELECT 1', error_handler=psql_err_handler, data_directory=data_directory)
                 else:
                     if program is PV_BIN:
                         extra_args = ['--quiet']
@@ -319,7 +319,7 @@ def main(argv=None):
             else:
                 external_programs = [LZOP_BIN, PSQL_BIN, PV_BIN]
 
-            external_program_check(external_programs)
+            external_program_check(external_programs, args.PG_CLUSTER_DIRECTORY)
             rate_limit = args.rate_limit
 
             while_offline = args.while_offline

--- a/wal_e/operator/s3_operator.py
+++ b/wal_e/operator/s3_operator.py
@@ -304,8 +304,8 @@ class S3Backup(object):
 
         try:
             if not while_offline:
-                start_backup_info = PgBackupStatements.run_start_backup()
-                version = PgBackupStatements.pg_version()['version']
+                start_backup_info = PgBackupStatements.run_start_backup(data_directory)
+                version = PgBackupStatements.pg_version(data_directory)['version']
             else:
                 if os.path.exists(os.path.join(data_directory,
                                                'postmaster.pid')):
@@ -335,7 +335,7 @@ class S3Backup(object):
                             'See README: TODO about pg_cancel_backup'))
 
             if not while_offline:
-                stop_backup_info = PgBackupStatements.run_stop_backup()
+                stop_backup_info = PgBackupStatements.run_stop_backup(data_directory)
             else:
                 stop_backup_info = start_backup_info
             backup_stop_good = True


### PR DESCRIPTION
I added the extract host and port to call psql. This solves the problem of a multicluster environment, backup-push didn't work correctly for the second instance because pg_start_backup/pg_stop_backup runs in the first cluster.
