### PR TITLE
Allow for IAM Role/Instance Profiles for auth

### DIFF
--- a/wal_e/operator/s3_operator.py
+++ b/wal_e/operator/s3_operator.py
@@ -32,9 +32,8 @@ class S3Backup(object):
 
     """
 
-    def __init__(self,
-                 aws_access_key_id, aws_secret_access_key, s3_prefix,
-                 gpg_key_id):
+    def __init__(self, s3_prefix, gpg_key_id, aws_access_key_id=None,
+                aws_secret_access_key=None):
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.gpg_key_id = gpg_key_id


### PR DESCRIPTION
Rather than having to have the aws secret key/aws access key anywhere on
an instance this patch allows for the use of Instance Profiles and IAM
Roles to access S3.

This patch removes the checks that ensure that you provided AWS_*
credentials, and instead catches the S3 exception when your attempts
fail due to AccessDenied.

Since boto has code to handle Instance Profiles I honestly didn't have
to do much, just let boto do its thing without provided keys.

Here's the blog post about this feature:

http://aws.typepad.com/aws/2012/06/iam-roles-for-ec2-instances-simplified-secure-access-to-aws-service-apis-from-ec2.html
