### PR TITLE
Fix upper case bucket names regression (from #3).

### DIFF
--- a/wal_e/worker/s3_worker.py
+++ b/wal_e/worker/s3_worker.py
@@ -18,7 +18,8 @@ import time
 import traceback
 
 from urlparse import urlparse
-from boto.s3.connection import S3Connection, SubdomainCallingFormat
+from boto.s3.connection import (S3Connection, SubdomainCallingFormat,
+                                OrdinaryCallingFormat)
 
 import wal_e.log_help as log_help
 import wal_e.storage.s3_storage as s3_storage
@@ -104,7 +105,10 @@ def s3_uri_wrap(s3_uri):
     names.
     """
     suri = boto.storage_uri(s3_uri, validate=False)
-    suri.connection_args = {'host': s3_endpoint_for_uri(s3_uri)}
+    suri.connection_args = {
+        'host': s3_endpoint_for_uri(s3_uri),
+        'calling_format': OrdinaryCallingFormat(),
+    }
     return suri
 
 


### PR DESCRIPTION
Evidently, boto.storage_uri called without extra connection arguments
constructed a connection object compatible with uppercase bucket names
(which I discovered today is only allowed in us-east-1; one gets an
error attempting to create a bucket with an uppercase name in all other
regions).  Issue #3 added a 'host' connection argument that appears to
have changed the configuration.  Explicitly request the appropriate
calling format.
#15
