### PR TITLE
ImportError: No module named Bucket

### DIFF
--- a/wal_e/cmd.py
+++ b/wal_e/cmd.py
@@ -362,7 +362,7 @@ def main(argv=None):
                 is_dry_run_really = True
 
                 import boto.s3.key
-                import boto.s3.Bucket
+                import boto.s3.bucket
 
                 # This is not necessary, but "just in case" to find bugs.
                 def just_error(*args, **kwargs):


### PR DESCRIPTION
A --dry-run on delete fails with
        DETAIL: Traceback (most recent call last):
          File "/usr/local/lib/python2.7/dist-packages/wal_e-0.7.dev-py2.7.egg/wal_e/cmd.py", line 365, in main
            import boto.s3.Bucket
        ImportError: No module named Bucket

This fixes the import
