### PR TITLE
Added push for existing archive

### DIFF
--- a/wal_e/VERSION
+++ b/wal_e/VERSION
@@ -1,1 +1,1 @@
-0.7.dev
+0.7.dev.odesk

--- a/wal_e/pipeline.py
+++ b/wal_e/pipeline.py
@@ -34,6 +34,24 @@ def get_upload_pipeline(in_fd, out_fd, rate_limit=None,
     return Pipeline(commands, in_fd, out_fd)
 
 
+def get_archive_upload_pipeline(in_fd, out_fd, rate_limit=None, gpg_key=None):
+    """
+    Create a UNIX pipeline to process a file for uploading.
+
+    Optionally encrypt.
+    """
+    commands = []
+    if rate_limit is not None:
+        commands.append(PipeViwerRateLimitFilter(rate_limit))
+    else:
+        commands.append(PipeViwerFilter())
+
+    if gpg_key is not None:
+        commands.append(GPGEncryptionFilter(gpg_key))
+
+    return Pipeline(commands, in_fd, out_fd)
+
+
 def get_download_pipeline(in_fd, out_fd, gpg=False):
     """ Create a pipeline to process a file after downloading.
         (Optionally decrypt, then decompress) """
@@ -169,6 +187,11 @@ class PipeViwerRateLimitFilter(PipelineCommand):
         PipelineCommand.__init__(
             self,
             [PV_BIN, '--rate-limit=' + unicode(rate_limit)], stdin, stdout)
+
+
+class PipeViwerFilter(PipelineCommand):
+    def __init__(self, stdin=PIPE, stdout=PIPE):
+        PipelineCommand.__init__(self, [PV_BIN], stdin, stdout)
 
 
 class LZOCompressionFilter(PipelineCommand):


### PR DESCRIPTION
Hi,

please take a look at the added functionality. It allows to upload existing archive of DB onto S3. We much prefer to have local backups given that it will take us much time to pull data out of S3. So uploading of existing archive  eliminates the need to backup twice - once for local copy and one more time for S3.

Do you think it may be added to the mainstream branch (we are open for refactoring because still working on it)?

Thanks for you work anyway!
