### PR TITLE
rename PipeViwerRateLimitFilter to PipeViewerRateLimitFilter

### DIFF
--- a/tests/test_pipeline_sanity.py
+++ b/tests/test_pipeline_sanity.py
@@ -11,7 +11,7 @@ def create_bogus_payload(dirname):
 def test_rate_limit(tmpdir):
     payload, payload_file = create_bogus_payload(tmpdir)
 
-    pl = pipeline.PipeViwerRateLimitFilter(1048576 * 100,
+    pl = pipeline.PipeViewerRateLimitFilter(1048576 * 100,
                                            stdin=payload_file.open())
     pl.start()
     round_trip = pl.stdout.read()

--- a/wal_e/pipeline.py
+++ b/wal_e/pipeline.py
@@ -25,7 +25,7 @@ def get_upload_pipeline(in_fd, out_fd, rate_limit=None,
         (Compress, and optionally encrypt) """
     commands = []
     if rate_limit is not None:
-        commands.append(PipeViwerRateLimitFilter(rate_limit))
+        commands.append(PipeViewerRateLimitFilter(rate_limit))
     commands.append(LZOCompressionFilter())
 
     if gpg_key is not None:
@@ -163,7 +163,7 @@ class PipelineCommand(object):
                 .format(" ".join(self._command), retcode))
 
 
-class PipeViwerRateLimitFilter(PipelineCommand):
+class PipeViewerRateLimitFilter(PipelineCommand):
     """ Limit the rate of transfer through a pipe using pv """
     def __init__(self, rate_limit, stdin=PIPE, stdout=PIPE):
         PipelineCommand.__init__(


### PR DESCRIPTION
There was an irritating typo in this filter name, it's now fixed.
