### PR TITLE
Implement --terse option

### DIFF
--- a/tests/test_log_help.py
+++ b/tests/test_log_help.py
@@ -1,6 +1,7 @@
 import re
+import logging
 
-import wal_e.log_help as log_help
+from wal_e import log_help
 
 
 def sanitize_log(log):
@@ -52,3 +53,43 @@ STRUCTURED: time=2012-01-01T00.1234-00 pid=1234 structured-data=yes"""
 DETAIL: The detail
 HINT: The hint
 STRUCTURED: time=2012-01-01T00.1234-00 pid=1234"""
+
+
+def test_log_levels(monkeypatch):
+    l = log_help.WalELogger()
+
+    class DidLog(object):
+        def __init__(self):
+            self.called = False
+
+        def __call__(self, *args, **kwargs):
+            self.called = True
+
+    # Try the default logging level, which should log INFO-level.
+    d = DidLog()
+    monkeypatch.setattr(l._logger, 'log', d)
+    l.log(level=logging.INFO, msg='hello')
+    assert d.called is True
+
+    # Test default elision of DEBUG-level statements.
+    d = DidLog()
+    monkeypatch.setattr(l._logger, 'log', d)
+    l.log(level=logging.DEBUG, msg='hello')
+    assert d.called is False
+
+    # Adjust log level ignore INFO and below
+    log_help.MINIMUM_LOG_LEVEL = logging.WARNING
+
+    # Test elision of INFO level statements once minimum level has
+    # been adjusted.
+    d = DidLog()
+    monkeypatch.setattr(l._logger, 'log', d)
+    l.log(level=logging.INFO, msg='hello')
+    assert d.called is False
+
+    # Make sure WARNING level is still logged even if minimum level
+    # has been adjusted.
+    d = DidLog()
+    monkeypatch.setattr(l._logger, 'log', d)
+    l.log(level=logging.WARNING, msg='HELLO!')
+    assert d.called is True

--- a/wal_e/cmd.py
+++ b/wal_e/cmd.py
@@ -86,7 +86,7 @@ from wal_e.worker.pg_controldata_worker import CONFIG_BIN, PgControlDataParser
 log_help.configure(
     format='%(name)-12s %(levelname)-8s %(message)s')
 
-logger = log_help.WalELogger('wal_e.main', level=logging.INFO)
+logger = log_help.WalELogger('wal_e.main')
 
 
 def external_program_check(
@@ -188,6 +188,10 @@ def main(argv=None):
         help='GPG key ID to encrypt to. (Also needed when decrypting.)  '
         'Can also be defined via environment variable '
         'WALE_GPG_KEY_ID')
+
+    parser.add_argument(
+        '--terse', action='store_true',
+        help='Only log messages as or more severe than a warning.')
 
     subparsers = parser.add_subparsers(title='subcommands',
                                        dest='subcommand')
@@ -311,6 +315,10 @@ def main(argv=None):
     # Okay, parse some arguments, finally
     args = parser.parse_args()
     subcommand = args.subcommand
+
+    # Adjust logging level if terse output is set.
+    if args.terse:
+        log_help.MINIMUM_LOG_LEVEL = logging.WARNING
 
     # Handle version printing specially, because it doesn't need
     # credentials.

--- a/wal_e/log_help.py
+++ b/wal_e/log_help.py
@@ -9,6 +9,10 @@ import logging.handlers
 import os
 
 
+# Minimum logging level to emit logs for, inclusive.
+MINIMUM_LOG_LEVEL = logging.INFO
+
+
 class IndentFormatter(logging.Formatter):
 
     def format(self, record, *args, **kwargs):
@@ -81,15 +85,7 @@ def configure(*args, **kwargs):
 
 class WalELogger(object):
     def __init__(self, *args, **kwargs):
-        # Enable a shortcut to create the logger and set its level all
-        # at once.  To do that, pop the level out of the dictionary,
-        # which will otherwise cause getLogger to explode.
-        level = kwargs.pop('level', None)
-
         self._logger = logging.getLogger(*args, **kwargs)
-
-        if level is not None:
-            self._logger.setLevel(level)
 
     @staticmethod
     def _fmt_structured(d):
@@ -129,6 +125,9 @@ class WalELogger(object):
         return '\n'.join(msg_parts)
 
     def log(self, level, msg, *args, **kwargs):
+        if level < MINIMUM_LOG_LEVEL:
+            return
+
         detail = kwargs.pop('detail', None)
         hint = kwargs.pop('hint', None)
         structured = kwargs.pop('structured', None)

--- a/wal_e/operator/s3_operator.py
+++ b/wal_e/operator/s3_operator.py
@@ -3,7 +3,6 @@ import gevent
 import gevent.pool
 import itertools
 import json
-import logging
 import os
 import sys
 
@@ -21,7 +20,7 @@ from wal_e.storage import s3_storage
 from wal_e.worker import PgBackupStatements
 from wal_e.worker import PgControlDataParser
 
-logger = log_help.WalELogger(__name__, level=logging.INFO)
+logger = log_help.WalELogger(__name__)
 
 # Provides guidence in object names as to the version of the file
 # structure.

--- a/wal_e/retries.py
+++ b/wal_e/retries.py
@@ -1,5 +1,4 @@
 import functools
-import logging
 import sys
 import traceback
 
@@ -7,7 +6,7 @@ import gevent
 
 import wal_e.log_help as log_help
 
-logger = log_help.WalELogger(__name__, level=logging.INFO)
+logger = log_help.WalELogger(__name__)
 
 
 def generic_exception_processor(exc_tup, **kwargs):

--- a/wal_e/s3/calling_format.py
+++ b/wal_e/s3/calling_format.py
@@ -1,11 +1,10 @@
 import boto
-import logging
 
 from boto import s3
 from boto.s3 import connection
 from wal_e import log_help
 
-logger = log_help.WalELogger(__name__, level=logging.INFO)
+logger = log_help.WalELogger(__name__)
 
 _S3_REGIONS = {
     # A map like this is actually defined in boto.s3 in newer versions of boto

--- a/wal_e/worker/s3_worker.py
+++ b/wal_e/worker/s3_worker.py
@@ -9,7 +9,6 @@ import boto
 import boto.exception
 import gevent
 import json
-import logging
 import re
 import socket
 import tarfile
@@ -29,7 +28,7 @@ from wal_e.retries import retry, retry_with_count
 from wal_e.s3 import calling_format
 from wal_e.worker import s3_deleter
 
-logger = log_help.WalELogger(__name__, level=logging.INFO)
+logger = log_help.WalELogger(__name__)
 
 
 generic_weird_key_hint_message = ('This means an unexpected key was found in '


### PR DESCRIPTION
Defined as suppressing logs of level INFO and below.

Altered from original '--quiet' patch with additional hacking from
Daniel Farina daniel@heroku.com.
