### PR TITLE
Fix __all__ to use strings

### DIFF
--- a/wal_e/blobstore/s3/__init__.py
+++ b/wal_e/blobstore/s3/__init__.py
@@ -3,7 +3,7 @@ from wal_e.blobstore.s3.s3_util import do_lzop_get
 from wal_e.blobstore.s3.s3_util import write_and_return_error
 
 __all__ = [
-    uri_put_file,
-    do_lzop_get,
-    write_and_return_error,
+    'do_lzop_get',
+    'uri_put_file',
+    'write_and_return_error',
 ]

--- a/wal_e/blobstore/wabs/__init__.py
+++ b/wal_e/blobstore/wabs/__init__.py
@@ -1,9 +1,9 @@
-from wal_e.blobstore.wabs.wabs_util import uri_put_file
 from wal_e.blobstore.wabs.wabs_util import do_lzop_get
+from wal_e.blobstore.wabs.wabs_util import uri_put_file
 from wal_e.blobstore.wabs.wabs_util import write_and_return_error
 
 __all__ = [
-    uri_put_file,
-    do_lzop_get,
-    write_and_return_error,
+    'do_lzop_get',
+    'uri_put_file',
+    'write_and_return_error',
 ]

--- a/wal_e/operator/__init__.py
+++ b/wal_e/operator/__init__.py
@@ -1,5 +1,5 @@
 from wal_e.operator.backup import get_backup_context
 
 __all__ = [
-    get_backup_context,
+    'get_backup_context',
 ]

--- a/wal_e/worker/__init__.py
+++ b/wal_e/worker/__init__.py
@@ -1,23 +1,23 @@
-from wal_e.worker.pg import PgControlDataParser
 from wal_e.worker.pg import PgBackupStatements
-from wal_e.worker.upload_pool import TarUploadPool
-from wal_e.worker.upload import WalUploader
-from wal_e.worker.upload import PartitionUploader
-from wal_e.worker.worker_util import uri_put_file
-from wal_e.worker.worker_util import do_lzop_get
-from wal_e.worker.worker_util import do_lzop_put
+from wal_e.worker.pg import PgControlDataParser
 from wal_e.worker.pg.wal_transfer import WalSegment
 from wal_e.worker.pg.wal_transfer import WalTransferGroup
+from wal_e.worker.upload import PartitionUploader
+from wal_e.worker.upload import WalUploader
+from wal_e.worker.upload_pool import TarUploadPool
+from wal_e.worker.worker_util import do_lzop_get
+from wal_e.worker.worker_util import do_lzop_put
+from wal_e.worker.worker_util import uri_put_file
 
 __all__ = [
-    PgBackupStatements,
-    PgControlDataParser,
-    TarUploadPool,
-    WalSegment,
-    WalTransferGroup,
-    WalUploader,
-    PartitionUploader,
-    uri_put_file,
-    do_lzop_get,
-    do_lzop_put,
+    'PartitionUploader',
+    'PgBackupStatements',
+    'PgControlDataParser',
+    'TarUploadPool',
+    'WalSegment',
+    'WalTransferGroup',
+    'WalUploader',
+    'do_lzop_get',
+    'do_lzop_put',
+    'uri_put_file',
 ]

--- a/wal_e/worker/pg/__init__.py
+++ b/wal_e/worker/pg/__init__.py
@@ -1,15 +1,15 @@
-from wal_e.worker.pg.pg_controldata_worker import PgControlDataParser
-from wal_e.worker.pg.pg_controldata_worker import CONTROLDATA_BIN
 from wal_e.worker.pg.pg_controldata_worker import CONFIG_BIN
-from wal_e.worker.pg.psql_worker import PgBackupStatements
+from wal_e.worker.pg.pg_controldata_worker import CONTROLDATA_BIN
+from wal_e.worker.pg.pg_controldata_worker import PgControlDataParser
 from wal_e.worker.pg.psql_worker import PSQL_BIN
+from wal_e.worker.pg.psql_worker import PgBackupStatements
 from wal_e.worker.pg.psql_worker import psql_csv_run
 
 __all__ = [
-    CONTROLDATA_BIN,
-    CONFIG_BIN,
-    PgControlDataParser,
-    PgBackupStatements,
-    PSQL_BIN,
-    psql_csv_run,
+    'CONTROLDATA_BIN',
+    'CONFIG_BIN',
+    'PgControlDataParser',
+    'PgBackupStatements',
+    'PSQL_BIN',
+    'psql_csv_run',
 ]

--- a/wal_e/worker/s3/__init__.py
+++ b/wal_e/worker/s3/__init__.py
@@ -1,13 +1,13 @@
-from wal_e.worker.s3.s3_worker import TarPartitionLister
+from wal_e.worker.s3.s3_deleter import Deleter
 from wal_e.worker.s3.s3_worker import BackupFetcher
 from wal_e.worker.s3.s3_worker import BackupList
 from wal_e.worker.s3.s3_worker import DeleteFromContext
-from wal_e.worker.s3.s3_deleter import Deleter
+from wal_e.worker.s3.s3_worker import TarPartitionLister
 
 __all__ = [
-    Deleter,
-    TarPartitionLister,
-    BackupFetcher,
-    BackupList,
-    DeleteFromContext,
+    'Deleter',
+    'TarPartitionLister',
+    'BackupFetcher',
+    'BackupList',
+    'DeleteFromContext',
 ]

--- a/wal_e/worker/wabs/__init__.py
+++ b/wal_e/worker/wabs/__init__.py
@@ -1,13 +1,13 @@
-from wal_e.worker.wabs.wabs_worker import TarPartitionLister
+from wal_e.worker.wabs.wabs_deleter import Deleter
 from wal_e.worker.wabs.wabs_worker import BackupFetcher
 from wal_e.worker.wabs.wabs_worker import BackupList
 from wal_e.worker.wabs.wabs_worker import DeleteFromContext
-from wal_e.worker.wabs.wabs_deleter import Deleter
+from wal_e.worker.wabs.wabs_worker import TarPartitionLister
 
 __all__ = [
-    Deleter,
-    TarPartitionLister,
-    BackupFetcher,
-    BackupList,
-    DeleteFromContext,
+    'BackupFetcher',
+    'BackupList',
+    'DeleteFromContext',
+    'Deleter',
+    'TarPartitionLister',
 ]


### PR DESCRIPTION
Also alphabetize all the import and **all** list lines, now that some
of the lists of exported functions are getting long enough to be
harder to scan.

Alex Gaynor alex.gaynor@gmail.com caught this systematic mistake of
mine in code review.
