### PR TITLE
Read atomic write pipe buffer size from system configuration in piper.py

### DIFF
--- a/wal_e/piper.py
+++ b/wal_e/piper.py
@@ -5,13 +5,12 @@ Utilities for handling subprocesses.
 Mostly necessary only because of http://bugs.python.org/issue1652.
 
 """
-
+import os
 import copy
 import errno
 import fcntl
 import gevent
 import gevent.socket
-import os
 import signal
 
 import sys
@@ -24,6 +23,10 @@ from wal_e.subprocess import PIPE
 # This is not used in this module, but is imported by dependent
 # modules, so do this to quiet pyflakes.
 assert PIPE
+
+# Determine the maximum number of bytes that can be written atomically
+# to a pipe
+PIPE_BUF_BYTES = os.pathconf('.', os.pathconf_names['PC_PIPE_BUF'])
 
 
 class NonBlockPipeFileWrap(object):
@@ -41,9 +44,9 @@ class NonBlockPipeFileWrap(object):
         while size is None or accum.tell() < size:
             try:
                 if size is None:
-                    max_read = 512
+                    max_read = PIPE_BUF_BYTES
                 else:
-                    max_read = min(512, size - accum.tell())
+                    max_read = min(PIPE_BUF_BYTES, size - accum.tell())
 
                 chunk = self._fp.read(max_read)
 
@@ -68,7 +71,8 @@ class NonBlockPipeFileWrap(object):
             try:
                 # self._fp.write() doesn't return anything, so use
                 # os.write.
-                bytes_written += os.write(self._fp.fileno(), buf.read(512))
+                bytes_written += os.write(self._fp.fileno(),
+                                          buf.read(PIPE_BUF_BYTES))
             except IOError, ex:
                 if ex[0] != errno.EAGAIN:
                     raise


### PR DESCRIPTION
This addresses the issue raised [here](https://github.com/wal-e/wal-e/pull/47#discussion-diff-7303422) regarding pipe read/write chunk sizes.
