### PR TITLE
Update README to document --pool-size parameter to wal_push

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -499,6 +499,21 @@ Quieter Logging
 To restrict log statements to warnings and errors, use the ``--terse``
 option. This is supported on all WAL-E operations.
 
+Increasing throughput of wal_push
+'''''''''''''''''''''''''''''''''
+
+In certain situations, the wal_push process can take long enough that it
+can't keep up with WAL segments being produced by the DB, which can lead
+to unbounded disk usage.
+
+You can instruct wal-e to pool WAL segments together and send them in groups
+by passing the "--pool-size / -p" parameter to wal_push.  This has been
+experienced to significantly increase wal_push throughput.
+
+In versions <=0.6.x, --pool-size defaults to 1.
+
+As of version 0.7.x, --pool-size defaults to 8.
+
 
 Development
 -----------


### PR DESCRIPTION
I had a serious issue which ended up being solved by the undocumented "pool size" option, to I thought I'd put in a brief mention of it to push people in the right direction.
