### PR TITLE
Fix timings

### DIFF
--- a/wal_e/worker/upload.py
+++ b/wal_e/worker/upload.py
@@ -127,9 +127,9 @@ class PartitionUploader(object):
 
             # Actually do work, retrying if necessary, and timing how long
             # it takes.
-            clock_start = time.clock()
+            clock_start = time.time()
             k = put_file_helper()
-            clock_finish = time.clock()
+            clock_finish = time.time()
 
             kib_per_second = format_kib_per_second(clock_start, clock_finish,
                                                    k.size)

--- a/wal_e/worker/worker_util.py
+++ b/wal_e/worker/worker_util.py
@@ -33,10 +33,10 @@ def do_lzop_put(creds, url, local_path, gpg_key):
 
         tf.flush()
 
-        clock_start = time.clock()
+        clock_start = time.time()
         tf.seek(0)
         k = blobstore.uri_put_file(creds, url, tf)
-        clock_finish = time.clock()
+        clock_finish = time.time()
 
         kib_per_second = format_kib_per_second(
             clock_start, clock_finish, k.size)


### PR DESCRIPTION
Fixes KiB per second calculations that gave incorrectly high values.

time.clock() uses processor time, excluding the time spent doing I/O, but I/O is what we want to measure when timing uploads, etc. Due to that the KiB/s values were quite a bit higher than the actual transfer speeds.

E.g:
wal_e.worker.upload INFO     MSG: begin uploading a base backup volume
        DETAIL: Uploading to "s3://x/basebackups_005/base_000000050000055D00000034_00000040/tar_partitions/part_0.tar.lzo".
        STRUCTURED: time=2014-01-07T13:27:54.881763-00 pid=26012
wal_e.worker.upload INFO     MSG: finish uploading a base backup volume
        DETAIL: Uploading to "s3://x/basebackups_005/base_000000050000055D00000034_00000040/tar_partitions/part_0.tar.lzo" complete at 74008.1KiB/s.
        STRUCTURED: time=2014-01-07T13:29:24.855229-00 pid=26012

The file size here was about 54768 KB and the actual upload speed was actually only about 609 KiB/s and not 74008.1KiB/s.

Noticed this when trying to figure out why the uploads were very slow, although the log line suggested that they were fast. 

Still haven't found out why it's so slow, though.
