### PR TITLE
Inspect .errno only on EnvironmentError in WABS support

### DIFF
--- a/wal_e/blobstore/wabs/wabs_util.py
+++ b/wal_e/blobstore/wabs/wabs_util.py
@@ -141,7 +141,7 @@ def uri_get_file(creds, uri, conn=None):
                         hint="")
                     gevent.sleep(30)
                 else:
-                    raise e
+                    raise
             else:
                 break
         length = len(part)


### PR DESCRIPTION
Previously, it would seem other exceptions would crash the program if
an errno was not present, and EnvironmentError typically is a parent
of exceptions that yield an errno.

@boldfield may want to review, as this is a wabs-only change.
