### PR TITLE
Change file mode from `rwb` to `r+b`

### DIFF
--- a/wal_e/worker/upload.py
+++ b/wal_e/worker/upload.py
@@ -71,7 +71,7 @@ class PartitionUploader(object):
         logger.info(msg='beginning volume compression',
                     detail='Building volume {name}.'.format(name=tpart.name))
 
-        with tempfile.NamedTemporaryFile(mode='rwb') as tf:
+        with tempfile.NamedTemporaryFile(mode='r+b') as tf:
             pipeline = get_upload_pipeline(PIPE, tf,
                                            rate_limit=self.rate_limit,
                                            gpg_key=self.gpg_key)

--- a/wal_e/worker/worker_util.py
+++ b/wal_e/worker/worker_util.py
@@ -26,7 +26,7 @@ def do_lzop_put(creds, url, local_path, gpg_key):
     assert url.endswith('.lzo')
     blobstore = get_blobstore(storage.StorageLayout(url))
 
-    with tempfile.NamedTemporaryFile(mode='rwb') as tf:
+    with tempfile.NamedTemporaryFile(mode='r+b') as tf:
         pipeline = get_upload_pipeline(
             open(local_path, 'r'), tf, gpg_key=gpg_key)
         pipeline.finish()


### PR DESCRIPTION
In `wal_e/worker/worker_util.py:29` and `wal_e/worker/upload.py:74` you
use `rwb` as file mode. If you look at the Python documentation for
[Reading and Writing files](http://docs.python.org/2/tutorial/inputoutput.html#reading-and-writing-files) you can see that the only possible options
are:
- `w` for write only
- `r` for read only
- `r+` for read and write

You can also always append `b` to open the file in binary mode. So I
think that in case of wal-e this should be `r+b` instead of `rwb`. I made
this change to fix an error I got on FreeBSD.
