### PR TITLE
Update README with a tutorial on passworded gpg keys. Add --batch to gpg  decryption to support it.

### DIFF
--- a/wal_e/pipeline.py
+++ b/wal_e/pipeline.py
@@ -213,7 +213,11 @@ class GPGEncryptionFilter(PipelineCommand):
 
 
 class GPGDecryptionFilter(PipelineCommand):
-    """ Decrypt using GPG (the private key must exist and be unpassworded). """
+    """Decrypt using GPG.
+
+    The private key must exist, and either be unpassworded, or the password
+    should be present in the gpg agent.
+    """
     def __init__(self, stdin=PIPE, stdout=PIPE):
         PipelineCommand.__init__(
-                self, [GPG_BIN, '-d', '-q'], stdin, stdout)
+                self, [GPG_BIN, '-d', '-q', '--batch'], stdin, stdout)


### PR DESCRIPTION
Hi, Daniel,

here's support of my workaround of how I use passworded gpg keys with wal-e successfully.

If the private key file is passworded, the recovery command will always fail without "--batch", even when the password is present in gpg agent.

This is because gpg always requires a tty, if --batch is not specified, and there's not way to access tty in the postgres restore_command.
