### PR TITLE
Fix broken behavior for finding LATEST backup

### DIFF
--- a/wal_e/worker/base.py
+++ b/wal_e/worker/base.py
@@ -111,8 +111,8 @@ class _BackupList(object):
 
         * a backup name (base_number_number)
 
-        * the psuedo-name LATEST, which finds the lexically highest
-          backup
+        * the psuedo-name LATEST, which finds the backup with the most recent
+          modification date
 
         """
 
@@ -130,7 +130,7 @@ class _BackupList(object):
 
             assert len(all_backups) > 0
 
-            all_backups.sort()
+            all_backups.sort(key=lambda bi: bi.last_modified)
             yield all_backups[-1]
         else:
             raise exception.UserException(


### PR DESCRIPTION
It had been sorting the list of all backups, and taking the final one... but it was just sorting python objects, so the sort order is basically where they showed up in memory.

The comment suggested it wanted to sort lexically, presumably by name (as if, in some past version of the code, the BackupInfo objects were just string names).

However, since the BackupInfo objects have a last_modified date, I went ahead and sorted by that (from what I could tell, all the types of storage always populate the last_modified date).
