### PR TITLE
Update wal_transfer.py

### DIFF
--- a/wal_e/worker/pg/wal_transfer.py
+++ b/wal_e/worker/pg/wal_transfer.py
@@ -87,7 +87,7 @@ class WalTransferGroup(object):
         self.transferer = transferer
 
         # Synchronization and tasks
-        self.wait_change = queue.Queue(maxsize=0)
+        self.wait_change = queue.Queue()
         self.expect = 0
         self.closed = False
 


### PR DESCRIPTION
Modified queue to avoid spammy deprecation warnings that make it past --terse.

/usr/lib/python2.6/site-packages/wal_e/worker/pg/wal_transfer.py:90: DeprecationWarning: Queue(0) now equivalent to Queue(None); if you want a channel, use Channel
