### PR TITLE
Remove optional dependencies from 'requirements.txt'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,14 +80,19 @@ will attempt to resolve them:
 
 * gevent>=0.13.1
 * boto>=2.6.0
+* argparse, if not on Python 2.7
+
+Optional Python dependencies (please install manually):
+
 * azure>=0.7.0
 * python-swiftclient>=1.8.0
 * python-keystoneclient>=0.4.2
-* argparse, if not on Python 2.7
+* python-daemon>=1.5.2
 
 It is possible to use WAL-E without the dependencies of back-end
 storage one does not use installed: the imports for those are only
 performed if the storage configuration demands their use.
+
 
 Backend Blob Store
 ------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
 gevent>=0.13.1
 boto>=2.6.0
-azure>=0.7.0
-python-swiftclient>=1.8.0
-python-keystoneclient>=0.4.2
-python-daemon>=1.5.2


### PR DESCRIPTION
Note that the entry-point scripts do not work when these dependencies
are declared - unless the packages are actually installed. This is how
setuptools works.

See comment: https://github.com/wal-e/wal-e/commit/079377095fa5d02904593a4a21f48...
