### PR TITLE
Ignore lost+found directory while walking through cluster dir.

### DIFF
--- a/wal_e/tar_partition.py
+++ b/wal_e/tar_partition.py
@@ -428,6 +428,9 @@ def _segmentation_guts(root, file_paths, max_partition_size):
 
 def partition(pg_cluster_dir):
     def raise_walk_error(e):
+        # Ignore root-owned system folder
+        if getattr(e, 'filename', '').endswith(os.path.sep + 'lost+found'):
+           return
         raise e
     if not pg_cluster_dir.endswith(os.path.sep):
         pg_cluster_dir += os.path.sep


### PR DESCRIPTION
Hi!

I have separate partition mounted to /var/lib/postgresql and it have root-owned lost+found directory.

This is what happens when I run backup-push:

```
wal_e.main   CRITICAL MSG: An unprocessed exception has avoided all error handling
        DETAIL: Traceback (most recent call last):
          File "/var/lib/wale-ve/6bc12a6fd47291c96fe8c1be713f4dd8/local/lib/python2.7/site-packages/wal_e/cmd.py", line 543, in main
            pool_size=args.pool_size)
          File "/var/lib/wale-ve/6bc12a6fd47291c96fe8c1be713f4dd8/local/lib/python2.7/site-packages/wal_e/operator/backup.py", line 194, in database_backup
            **kwargs)
          File "/var/lib/wale-ve/6bc12a6fd47291c96fe8c1be713f4dd8/local/lib/python2.7/site-packages/wal_e/operator/backup.py", line 374, in _upload_pg_cluster_dir
            spec, parts = tar_partition.partition(pg_cluster_dir)
          File "/var/lib/wale-ve/6bc12a6fd47291c96fe8c1be713f4dd8/local/lib/python2.7/site-packages/wal_e/tar_partition.py", line 443, in partition
            for root, dirnames, filenames in walker:
          File "/var/lib/wale-ve/6bc12a6fd47291c96fe8c1be713f4dd8/lib/python2.7/os.py", line 294, in walk
            for x in walk(new_path, topdown, onerror, followlinks):
          File "/var/lib/wale-ve/6bc12a6fd47291c96fe8c1be713f4dd8/lib/python2.7/os.py", line 279, in walk
            onerror(err)
          File "/var/lib/wale-ve/6bc12a6fd47291c96fe8c1be713f4dd8/local/lib/python2.7/site-packages/wal_e/tar_partition.py", line 431, in raise_walk_error
            raise e
        OSError: [Errno 13] Permission denied: '/var/lib/postgresql/lost+found'

        STRUCTURED: time=2014-08-13T18:12:52.681912-00 pid=31396
```

I feel guilty for adding magic-word into this clean code but I found no better design way for it :)
