### PR TITLE
Allow S3 Host override

### DIFF
--- a/wal_e/blobstore/s3/calling_format.py
+++ b/wal_e/blobstore/s3/calling_format.py
@@ -1,4 +1,5 @@
 import boto
+import os
 
 from boto import s3
 from boto.s3 import connection
@@ -88,6 +89,11 @@ def _connect_secureish(*args, **kwargs):
         kwargs['validate_certs'] = True
 
     kwargs['is_secure'] = True
+    
+    # implement s3 host override
+    host = os.getenv('S3_HOST')
+    if host is not None:
+        kwargs['host'] = host
 
     return connection.S3Connection(*args, **kwargs)
 


### PR DESCRIPTION
To support a S3 Proxy an override of the host is required. This pull request supports the override via the environment variable `S3_HOST`

fixes #129
