### PR TITLE
operator.backup: update wal_prefetch() so that failed downloads are deleted

### DIFF
--- a/wal_e/operator/backup.py
+++ b/wal_e/operator/backup.py
@@ -371,6 +371,16 @@ class Backup(object):
 
             ret = do_lzop_get(self.creds, url, d.dest,
                               self.gpg_key_id is not None, do_retry=False)
+            if not ret:
+                # If the download failed, AtomicDownload.__exit__()
+                # must be informed so that it does not link an empty
+                # archive file into place.
+                #
+                # We thus raise SystemExit. This is acceptable for
+                # prefetch since prefetch execution is daemonized.
+                # I.e., PostgreSQL has no knowledge of prefetch
+                # exit codes.
+                raise SystemExit('Failed to prefetch %s' % segment_name)
 
             logger.info(
                 msg='complete wal restore',


### PR DESCRIPTION
Resolves the issue in v0.8c1 detailed at:

```
https://groups.google.com/forum/#!topic/wal-e/8wwiDkrNLXQ
```

wherein (standby_mode = off) PostgreSQL recoveries were failing when
--prefetch > 0. Specifically, in cases where do_lzop_get() failed to
fetch an archive file (as would be the case when trying to fetch the
non-existent WAL file following the latest one in the archive) prefetch
was creating an empty archive file and then allowing AtomicDownload to
link that file into place. This causes PostgreSQL's recovery to fail.
PostgreSQL then shuts down and can't be started up until you remove
recovery.conf.

Sorry to not include a test for this; I've had difficulties getting tox up and
running in my environment. My best guess would be to add a test to
test_blackbox.py along the lines of test_wal_fetch_non_existent(). I'm
not certain, however.
