### PR TITLE
Fix typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -562,7 +562,7 @@ variables:
 To restrict log statements to warnings and errors, use the ``--terse``
 option.
 
-Increasing throughput of wal_push
+Increasing throughput of wal-push
 '''''''''''''''''''''''''''''''''
 
 In certain situations, the ``wal-push`` process can take long enough


### PR DESCRIPTION
The command is wal-push, not wal_push.
