### PR TITLE
restore-spec fix

### DIFF
--- a/wal_e/operator/backup.py
+++ b/wal_e/operator/backup.py
@@ -116,7 +116,8 @@ class Backup(object):
                 with open(restore_spec, 'r') as fs:
                     spec = json.load(fs)
                 backup_info.spec.update(spec)
-            if 'base_prefix' not in backup_info.spec or not backup_info.spec['base_prefix']:
+            if 'base_prefix' not in backup_info.spec \
+                    or not backup_info.spec['base_prefix']:
                 backup_info.spec['base_prefix'] = pg_cluster_dir
             self._build_restore_paths(backup_info.spec)
         else:


### PR DESCRIPTION
This PR fix two bugs:
- if 'base_prefix' not in spec throw exception as spec doesn't exist
- checking/creating tblspc_prefix even if path_prefix exist
