### PR TITLE
Return non-zero exit code and do not create empty file for wal-fetch

### DIFF
--- a/wal_e/operator/backup.py
+++ b/wal_e/operator/backup.py
@@ -354,6 +354,17 @@ class Backup(object):
         ret = do_lzop_get(self.creds, url, wal_destination,
                           self.gpg_key_id is not None)
 
+        if not ret:
+            # If the download failed, AtomicDownload.__exit__()
+            # must be informed so that it does not link an empty
+            # archive file into place.
+            #
+            # We thus raise SystemExit. This is acceptable for
+            # prefetch since prefetch execution is daemonized.
+            # I.e., PostgreSQL has no knowledge of prefetch
+            # exit codes.
+            raise SystemExit('Failed to prefetch %s' % wal_name)
+
         logger.info(
             msg='complete wal restore',
             structured={'action': 'wal-fetch',


### PR DESCRIPTION
The same problem as here https://github.com/wal-e/wal-e/pull/144

I just copy this part from wal_prefetch method.

When you recovery from backup and use standby_mode=off in recovery.conf, it waits to non zero exit code to move recovery.conf to recovery.done and start cluster.

But if wal-e creates zero lenght wal file, pg just shutdown with error.