### PR TITLE
Delete zero length wal-log

### DIFF
--- a/wal_e/operator/backup.py
+++ b/wal_e/operator/backup.py
@@ -354,6 +354,17 @@ class Backup(object):
         ret = do_lzop_get(self.creds, url, wal_destination,
                           self.gpg_key_id is not None)
 
+        if not ret:
+            # If the download failed, AtomicDownload.__exit__()
+            # must be informed so that it does not link an empty
+            # archive file into place.
+            #
+            # We thus raise SystemExit. This is acceptable for
+            # prefetch since prefetch execution is daemonized.
+            # I.e., PostgreSQL has no knowledge of prefetch
+            # exit codes.
+            raise SystemExit('Failed to prefetch %s' % wal_name)
+
         logger.info(
             msg='complete wal restore',
             structured={'action': 'wal-fetch',

--- a/wal_e/operator/backup.py
+++ b/wal_e/operator/backup.py
@@ -363,7 +363,8 @@ class Backup(object):
             # prefetch since prefetch execution is daemonized.
             # I.e., PostgreSQL has no knowledge of prefetch
             # exit codes.
-            raise SystemExit('Failed to prefetch %s' % wal_name)
+            os.remove(wal_destination)
+            raise SystemExit('Failed to fetch %s' % wal_name)
 
         logger.info(
             msg='complete wal restore',


### PR DESCRIPTION
When you use recovery.conf with standby_mode = off, pg move recovery.conf to recovery.done when there is no new wal-logs. But if we get zero length wal-log, pg shutdown with error:

```
wal_e.blobstore.s3.s3_util WARNING MSG: could no longer locate object while performing wal restore
DETAIL: The absolute URI that could not be located is s3://my-db-backups/db03.myhost.com/wal_005/00000001000000120000005F.lzo.
HINT: This can be normal when Postgres is trying to detect what timelines are available during restoration.
STRUCTURED: time=2015-03-06T13:08:49.191749-00 pid=27624
2015-03-06 13:08:49 UTC FATAL: archive file "00000001000000120000005F" has wrong size: 0 instead of 16777216
```

So we should exit with non-zero exit code and delete zero-length wal-log file. This works for me and helps automatically restore backups by cron.