### PR TITLE
Change flag to support busybox lzop.

### DIFF
--- a/wal_e/pipeline.py
+++ b/wal_e/pipeline.py
@@ -227,14 +227,14 @@ class LZOCompressionFilter(PipelineCommand):
     """ Compress using LZO. """
     def __init__(self, stdin=PIPE, stdout=PIPE):
         PipelineCommand.__init__(
-            self, [LZOP_BIN, '--stdout'], stdin, stdout)
+            self, [LZOP_BIN, '-c'], stdin, stdout)
 
 
 class LZODecompressionFilter(PipelineCommand):
     """ Decompress using LZO. """
     def __init__(self, stdin=PIPE, stdout=PIPE):
         PipelineCommand.__init__(
-                self, [LZOP_BIN, '-d', '--stdout', '-'], stdin, stdout)
+                self, [LZOP_BIN, '-d', '-c', '-'], stdin, stdout)
 
 
 class GPGEncryptionFilter(PipelineCommand):


### PR DESCRIPTION
From the lzop man page: http://www.lzop.org/lzop_man.php
```
-c, --stdout, --to-stdout Write output on standard output. If there are several input files, the output consists of a sequence of independently (de)compressed members. To obtain better compression, concatenate all input files before compressing them.
```

`--stdout` and `--to-stdout` are aliases to `-c`.

Unfortunatelly in `busybox` based distros (like `alpine linux`) only `-c` is a valid flag.

This pull request replaces `--stdout` with `-c`


**Fedora:**
```
aledbf:~ aledbf$ docker run -it fedora:latest /bin/bash
bash-4.3# yum install lzop
fedora/21/x86_64/metalink                                                                                                                                                                                                                                | 2.8 kB  00:00:00
fedora                                                                                                                                                                                                                                                   | 3.8 kB  00:00:00
updates/21/x86_64/metalink                                                                                                                                                                                                                               | 2.3 kB  00:00:00
updates                                                                                                                                                                                                                                                  | 4.9 kB  00:00:00
(1/4): fedora/21/x86_64/group_gz                                                                                                                                                                                                                         | 232 kB  00:00:00
(2/4): updates/21/x86_64/group_gz                                                                                                                                                                                                                        | 398 kB  00:00:02
(3/4): fedora/21/x86_64/primary_db                                                                                                                                                                                                                       |  17 MB  00:00:05
(4/4): updates/21/x86_64/primary_db                                                                                                                                                                                                                      | 5.9 MB  00:00:06
(1/2): updates/21/x86_64/updateinfo                                                                                                                                                                                                                      | 770 kB  00:00:01
(2/2): updates/21/x86_64/pkgtags                                                                                                                                                                                                                         | 1.4 MB  00:00:00
Resolving Dependencies
--> Running transaction check
---> Package lzop.x86_64 0:1.03-11.fc21 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================================================================================================================================================================================================================
 Package                                                        Arch                                                             Version                                                                 Repository                                                        Size
================================================================================================================================================================================================================================================================================
Installing:
 lzop                                                           x86_64                                                           1.03-11.fc21                                                            fedora                                                            58 k

Transaction Summary
================================================================================================================================================================================================================================================================================
Install  1 Package

Total download size: 58 k
Installed size: 99 k
Is this ok [y/d/N]: y
Downloading packages:
lzop-1.03-11.fc21.x86_64.rpm                                                                                                                                                                                                                             |  58 kB  00:00:00
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : lzop-1.03-11.fc21.x86_64                                                                                                                                                                                                                                     1/1
  Verifying  : lzop-1.03-11.fc21.x86_64                                                                                                                                                                                                                                     1/1

Installed:
  lzop.x86_64 0:1.03-11.fc21

Complete!
bash-4.3# lzop -h
                          Lempel-Ziv-Oberhumer Packer
                           Copyright (C) 1996 - 2010
lzop v1.03         Markus Franz Xaver Johannes Oberhumer          Nov 1st 2010

Usage: lzop [-dxlthIVL19] [-qvcfFnNPkUp] [-o file] [-S suffix] [file..]

Commands:
  -1     compress faster                   -9    compress better
  -d     decompress                        -x    extract (same as -dPp)
  -l     list compressed file              -I    display system information
  -t     test compressed file              -V    display version number
  -h     give this help                    -L    display software license
Options:
  -q     be quiet                          -v       be verbose
  -c     write on standard output          -oFILE   write output to 'FILE'
  -p     write output to current dir       -pDIR    write to path 'DIR'
  -f     force overwrite of output files
  -n     do not restore the original file name (default)
  -N     restore the original file name
  -P     restore or save the original path and file name
  -S.suf use suffix .suf on compressed files
  -U     delete input files after successful operation (like gzip and bzip2)
  file.. files to (de)compress. If none given, try standard input.
```

**Centos:**
```
aledbf:~ aledbf$ docker run -it centos:latest /bin/bash
[root@56ac6a364178 /]# yum install lzop
Loaded plugins: fastestmirror
base                                                                                                                                                                                                                                                     | 3.6 kB  00:00:00
extras                                                                                                                                                                                                                                                   | 3.4 kB  00:00:00
updates                                                                                                                                                                                                                                                  | 3.4 kB  00:00:00
(1/4): base/7/x86_64/group_gz                                                                                                                                                                                                                            | 157 kB  00:00:00
(2/4): updates/7/x86_64/primary_db                                                                                                                                                                                                                       | 6.6 MB  00:00:01
(3/4): extras/7/x86_64/primary_db                                                                                                                                                                                                                        |  43 kB  00:00:01
(4/4): base/7/x86_64/primary_db                                                                                                                                                                                                                          | 4.9 MB  00:00:02
Determining fastest mirrors
 * base: mirror.globo.com
 * extras: mirror.globo.com
 * updates: mirror.globo.com
Resolving Dependencies
--> Running transaction check
---> Package lzop.x86_64 0:1.03-10.el7 will be installed
--> Processing Dependency: liblzo2.so.2()(64bit) for package: lzop-1.03-10.el7.x86_64
--> Running transaction check
---> Package lzo.x86_64 0:2.06-6.el7_0.2 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================================================================================================================================================================================================================
 Package                                                       Arch                                                            Version                                                                   Repository                                                        Size
================================================================================================================================================================================================================================================================================
Installing:
 lzop                                                          x86_64                                                          1.03-10.el7                                                               base                                                              54 k
Installing for dependencies:
 lzo                                                           x86_64                                                          2.06-6.el7_0.2                                                            updates                                                           59 k

Transaction Summary
================================================================================================================================================================================================================================================================================
Install  1 Package (+1 Dependent package)

Total download size: 112 k
Installed size: 261 k
Is this ok [y/d/N]: y
Downloading packages:
warning: /var/cache/yum/x86_64/7/updates/packages/lzo-2.06-6.el7_0.2.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID f4a80eb5: NOKEY                                                                                                       ]  0.0 B/s |    0 B  --:--:-- ETA
Public key for lzo-2.06-6.el7_0.2.x86_64.rpm is not installed
(1/2): lzo-2.06-6.el7_0.2.x86_64.rpm                                                                                                                                                                                                                     |  59 kB  00:00:01
Public key for lzop-1.03-10.el7.x86_64.rpm is not installed
(2/2): lzop-1.03-10.el7.x86_64.rpm                                                                                                                                                                                                                       |  54 kB  00:00:01
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                                                                                                            79 kB/s | 112 kB  00:00:01
Retrieving key from file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
Importing GPG key 0xF4A80EB5:
 Userid     : "CentOS-7 Key (CentOS 7 Official Signing Key) <security@centos.org>"
 Fingerprint: 6341 ab27 53d7 8a78 a7c2 7bb1 24c6 a8a7 f4a8 0eb5
 Package    : centos-release-7-0.1406.el7.centos.2.6.x86_64 (@Updates/$releasever)
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
Is this ok [y/N]: y
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : lzo-2.06-6.el7_0.2.x86_64                                                                                                                                                                                                                                    1/2
  Installing : lzop-1.03-10.el7.x86_64                                                                                                                                                                                                                                      2/2
  Verifying  : lzop-1.03-10.el7.x86_64                                                                                                                                                                                                                                      1/2
  Verifying  : lzo-2.06-6.el7_0.2.x86_64                                                                                                                                                                                                                                    2/2

Installed:
  lzop.x86_64 0:1.03-10.el7

Dependency Installed:
  lzo.x86_64 0:2.06-6.el7_0.2

Complete!
[root@56ac6a364178 /]# lzop -h
                          Lempel-Ziv-Oberhumer Packer
                           Copyright (C) 1996 - 2010
lzop v1.03         Markus Franz Xaver Johannes Oberhumer          Nov 1st 2010

Usage: lzop [-dxlthIVL19] [-qvcfFnNPkUp] [-o file] [-S suffix] [file..]

Commands:
  -1     compress faster                   -9    compress better
  -d     decompress                        -x    extract (same as -dPp)
  -l     list compressed file              -I    display system information
  -t     test compressed file              -V    display version number
  -h     give this help                    -L    display software license
Options:
  -q     be quiet                          -v       be verbose
  -c     write on standard output          -oFILE   write output to 'FILE'
  -p     write output to current dir       -pDIR    write to path 'DIR'
  -f     force overwrite of output files
  -n     do not restore the original file name (default)
  -N     restore the original file name
  -P     restore or save the original path and file name
  -S.suf use suffix .suf on compressed files
  -U     delete input files after successful operation (like gzip and bzip2)
  file.. files to (de)compress. If none given, try standard input.
```

**Ubuntu:**
```
aledbf:~ aledbf$ docker run -it ubuntu:latest /bin/bash
Unable to find image 'ubuntu:latest' locally
f3c84ac3a053: Pull complete
f3c84ac3a053: Download complete
a1a958a24818: Download complete
9fec74352904: Download complete
d0955f21bf24: Download complete
511136ea3c5a: Download complete
Status: Downloaded newer image for ubuntu:latest
root@847d095fbdbe:/#
root@847d095fbdbe:/# apt-get update && apt-get install -y lzop
Ign http://archive.ubuntu.com trusty InRelease
Ign http://archive.ubuntu.com trusty-updates InRelease
Ign http://archive.ubuntu.com trusty-security InRelease
Hit http://archive.ubuntu.com trusty Release.gpg
Get:1 http://archive.ubuntu.com trusty-updates Release.gpg [933 B]
Get:2 http://archive.ubuntu.com trusty-security Release.gpg [933 B]
Hit http://archive.ubuntu.com trusty Release
Get:3 http://archive.ubuntu.com trusty-updates Release [63.5 kB]
Get:4 http://archive.ubuntu.com trusty-security Release [63.5 kB]
Get:5 http://archive.ubuntu.com trusty/main Sources [1335 kB]
Get:6 http://archive.ubuntu.com trusty/restricted Sources [5335 B]
Get:7 http://archive.ubuntu.com trusty/universe Sources [7926 kB]
Get:8 http://archive.ubuntu.com trusty/main amd64 Packages [1743 kB]
Get:9 http://archive.ubuntu.com trusty/restricted amd64 Packages [16.0 kB]
Get:10 http://archive.ubuntu.com trusty/universe amd64 Packages [7589 kB]
Get:11 http://archive.ubuntu.com trusty-updates/main Sources [240 kB]
Get:12 http://archive.ubuntu.com trusty-updates/restricted Sources [2310 B]
Get:13 http://archive.ubuntu.com trusty-updates/universe Sources [133 kB]
Get:14 http://archive.ubuntu.com trusty-updates/main amd64 Packages [618 kB]
Get:15 http://archive.ubuntu.com trusty-updates/restricted amd64 Packages [15.1 kB]
Get:16 http://archive.ubuntu.com trusty-updates/universe amd64 Packages [340 kB]
Get:17 http://archive.ubuntu.com trusty-security/main Sources [93.7 kB]
Get:18 http://archive.ubuntu.com trusty-security/restricted Sources [1874 B]
Get:19 http://archive.ubuntu.com trusty-security/universe Sources [19.6 kB]
Get:20 http://archive.ubuntu.com trusty-security/main amd64 Packages [320 kB]
Get:21 http://archive.ubuntu.com trusty-security/restricted amd64 Packages [14.8 kB]
Get:22 http://archive.ubuntu.com trusty-security/universe amd64 Packages [116 kB]
Fetched 20.7 MB in 28s (736 kB/s)
Reading package lists... Done
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following extra packages will be installed:
  liblzo2-2
The following NEW packages will be installed:
  liblzo2-2 lzop
0 upgraded, 2 newly installed, 0 to remove and 6 not upgraded.
Need to get 89.5 kB of archives.
After this operation, 298 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu/ trusty-updates/main liblzo2-2 amd64 2.06-1.2ubuntu1.1 [46.1 kB]
Get:2 http://archive.ubuntu.com/ubuntu/ trusty/universe lzop amd64 1.03-3 [43.4 kB]
Fetched 89.5 kB in 2s (39.0 kB/s)
Selecting previously unselected package liblzo2-2:amd64.
(Reading database ... 11527 files and directories currently installed.)
Preparing to unpack .../liblzo2-2_2.06-1.2ubuntu1.1_amd64.deb ...
Unpacking liblzo2-2:amd64 (2.06-1.2ubuntu1.1) ...
Selecting previously unselected package lzop.
Preparing to unpack .../archives/lzop_1.03-3_amd64.deb ...
Unpacking lzop (1.03-3) ...
Setting up liblzo2-2:amd64 (2.06-1.2ubuntu1.1) ...
Setting up lzop (1.03-3) ...
Processing triggers for libc-bin (2.19-0ubuntu6.6) ...
root@847d095fbdbe:/# lzop -h
                          Lempel-Ziv-Oberhumer Packer
                           Copyright (C) 1996 - 2010
lzop v1.03         Markus Franz Xaver Johannes Oberhumer          Nov 1st 2010

Usage: lzop [-dxlthIVL19] [-qvcfFnNPkUp] [-o file] [-S suffix] [file..]

Commands:
  -1     compress faster                   -9    compress better
  -d     decompress                        -x    extract (same as -dPp)
  -l     list compressed file              -I    display system information
  -t     test compressed file              -V    display version number
  -h     give this help                    -L    display software license
Options:
  -q     be quiet                          -v       be verbose
  -c     write on standard output          -oFILE   write output to 'FILE'
  -p     write output to current dir       -pDIR    write to path 'DIR'
  -f     force overwrite of output files
  -n     do not restore the original file name (default)
  -N     restore the original file name
  -P     restore or save the original path and file name
  -S.suf use suffix .suf on compressed files
  -U     delete input files after successful operation (like gzip and bzip2)
  file.. files to (de)compress. If none given, try standard input.
```

**Debian:**
```
aledbf:~ aledbf$ docker run -it debian:jessie /bin/bash
root@02e99ecec52b:/# apt-get update && apt-get install lzop
Get:1 http://security.debian.org jessie/updates InRelease [84.1 kB]
Get:2 http://http.debian.net jessie InRelease [199 kB]
Get:3 http://http.debian.net jessie-updates InRelease [117 kB]
Get:4 http://security.debian.org jessie/updates/main amd64 Packages [465 B]
Get:5 http://http.debian.net jessie/main amd64 Packages [9042 kB]
Get:6 http://http.debian.net jessie-updates/main amd64 Packages [20 B]
Fetched 9443 kB in 7s (1214 kB/s)
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
The following extra packages will be installed:
  liblzo2-2
The following NEW packages will be installed:
  liblzo2-2 lzop
0 upgraded, 2 newly installed, 0 to remove and 12 not upgraded.
Need to get 99.4 kB of archives.
After this operation, 267 kB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 http://http.debian.net/debian/ jessie/main liblzo2-2 amd64 2.08-1.2 [54.6 kB]
Get:2 http://http.debian.net/debian/ jessie/main lzop amd64 1.03-3 [44.8 kB]
Fetched 99.4 kB in 2s (45.1 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package liblzo2-2:amd64.
(Reading database ... 7527 files and directories currently installed.)
Preparing to unpack .../liblzo2-2_2.08-1.2_amd64.deb ...
Unpacking liblzo2-2:amd64 (2.08-1.2) ...
Selecting previously unselected package lzop.
Preparing to unpack .../archives/lzop_1.03-3_amd64.deb ...
Unpacking lzop (1.03-3) ...
Setting up liblzo2-2:amd64 (2.08-1.2) ...
Setting up lzop (1.03-3) ...
Processing triggers for libc-bin (2.19-15) ...
root@02e99ecec52b:/# lzop -h
                          Lempel-Ziv-Oberhumer Packer
                           Copyright (C) 1996 - 2010
lzop v1.03         Markus Franz Xaver Johannes Oberhumer          Nov 1st 2010

Usage: lzop [-dxlthIVL19] [-qvcfFnNPkUp] [-o file] [-S suffix] [file..]

Commands:
  -1     compress faster                   -9    compress better
  -d     decompress                        -x    extract (same as -dPp)
  -l     list compressed file              -I    display system information
  -t     test compressed file              -V    display version number
  -h     give this help                    -L    display software license
Options:
  -q     be quiet                          -v       be verbose
  -c     write on standard output          -oFILE   write output to 'FILE'
  -p     write output to current dir       -pDIR    write to path 'DIR'
  -f     force overwrite of output files
  -n     do not restore the original file name (default)
  -N     restore the original file name
  -P     restore or save the original path and file name
  -S.suf use suffix .suf on compressed files
  -U     delete input files after successful operation (like gzip and bzip2)
  file.. files to (de)compress. If none given, try standard input.
```
**Gentoo:**
(too long) https://gist.githubusercontent.com/aledbf/1c0253f1b62b6d772bb9/raw/gentoo%20lzop
