### PR TITLE
move invalid syslog facility test inside syslog conditional, see https:/...

### DIFF
--- a/wal_e/log_help.py
+++ b/wal_e/log_help.py
@@ -80,6 +80,10 @@ def configure(*args, **kwargs):
     valid_facility = False
     if 'syslog' in log_destinations:
         facility, valid_facility = get_syslog_facility()
+    
+        if not valid_facility:
+            terrible_log_output('invalid syslog facility level specified')
+    
         try:
             # Add syslog output.
             HANDLERS.append(handlers.SysLogHandler(syslog_address,
@@ -102,10 +106,6 @@ def configure(*args, **kwargs):
 
     # Default to INFO level logging.
     set_level(kwargs.get('level', logging.INFO))
-
-    if not valid_facility:
-        WalELogger(__name__).warning(
-            msg='invalid syslog facility level specified')
 
 
 def get_log_destinations():


### PR DESCRIPTION
.../github.com/wal-e/wal-e/issues/173

Note that I switched from using WalELogger to terrible_log_output because using the former resulted in `No handlers could be found for logger "wal_e.log_help"` being printed instead of the error message.  Arguably it makes sense anyway for an error which is reporting a logging misconfiguration to bypass fancy logging and go straight to stderr.