### PR TITLE
Require oslo.config 1.12.0 or later

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 gevent>=0.13.1
 boto>=2.6.0
 azure>=0.7.0
+oslo.config>=1.12.0
 python-swiftclient>=1.8.0
 python-keystoneclient>=0.4.2


### PR DESCRIPTION
While it doesn't actually have a runtime requirement for the `pbr` library, [`oslo.config` had specified one](https://github.com/openstack/oslo.config/commit/cc9940f91ebf91c9b827462441d0ea9b8b3b0efd), and it conflicted with [`python-keystoneclient`'s requirements](https://github.com/openstack/python-keystoneclient/blob/master/requirements.txt) for the same library. The newer version of `oslo.config` drops any `pbr` requirement.

Closes #181.