### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ boto>=2.6.0
 azure>=0.7.0
 python-swiftclient>=1.8.0
 python-keystoneclient>=0.4.2
+requests>=2.5.2
+six>=1.9.0
+pbr>=0.11,<1.0


### PR DESCRIPTION
Currently wal-e isn't installable via pip in functioning form.
This was sufficient to correct that for me but I am not sure if these constraints are the best.