### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ is appropriate for the store you are using.
 Dependencies
 ------------
 
-* python (>= 2.6)
+* python (>= 2.7)
 * lzop
 * psql (>= 8.4)
 * pv
@@ -640,14 +640,11 @@ the tox_ configuration included with WAL-E.
 
 To run the tests, one need only run::
 
-  $ tox
-
-However, if one does not have both Python 2.6 and 2.7 installed
-simultaneously (WAL-E supports both and tests both), there will be
-errors in running tox_ as seen previously.  One can restrict the test
-to the Python of one's choice to avoid that::
-
   $ tox -e py27
+
+There are a variety of other environments tested by ``tox`` handling
+old and new library versions, but ``-e py27`` is normally the
+environment one should iterate with.
 
 To run a somewhat more lengthy suite of integration tests that
 communicate with AWS S3, one might run tox_ like this::
@@ -658,7 +655,7 @@ communicate with AWS S3, one might run tox_ like this::
     WALE_WABS_INTEGRATION_TESTS=TRUE    \
     WABS_ACCOUNT_NAME=[...]             \
     WABS_ACCESS_KEY=[...]               \
-    tox -- -n 8
+    tox -e py27 -- -n 8
 
 Looking carefully at the above, notice the ``-n 8`` added the tox_
 invocation.  This ``-n 8`` is after a ``--`` that indicates to tox_

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,12 @@
 [tox]
 skipsdist=True
 
-[testenv:py26]
-basepython = python2.6
-
 [testenv:py27]
 basepython = python2.7
 
 # Oldest sensitive dependencies supported with WAL-E 0.7.
 [testenv:0.8-oldest]
-basepython = python2.6
+basepython = python2.7
 deps =
     boto==2.6.0
     azure==0.7.0
@@ -18,13 +15,6 @@ deps =
     gevent==0.13.1
     python-daemon==1.5.2
     {[base]deps}
-
-# Test new botos, by request of boto maintainer Daniel G. Taylor.
-[testenv:boto-tip-2.6]
-basepython = python2.6
-deps =
-     git+git://github.com/boto/boto.git#egg=boto
-     {[base]deps}
 
 [testenv:boto-tip-2.7]
 basepython = python2.7


### PR DESCRIPTION
Because the Azure driver has since dropped support and this was making
test failures noisy.