### PR TITLE
add timeout param to backup-push

### DIFF
--- a/wal_e/cmd.py
+++ b/wal_e/cmd.py
@@ -271,6 +271,14 @@ def build_parser():
         dest='while_offline',
         action='store_true',
         default=False)
+    backup_push_parser.add_argument(
+        '--timeout',
+        help=('Statement timeout in milliseconds per psql command. '
+              '"0" disables the timeout. See '
+              'http://www.postgresql.org/docs/9.3/static/'
+              'runtime-config-client.html#GUC-STATEMENT-TIMEOUT'),
+        type=int,
+        default=None)
 
     # wal-push operator section
     wal_push_parser = subparsers.add_parser(
@@ -569,7 +577,8 @@ def main():
                 args.PG_CLUSTER_DIRECTORY,
                 rate_limit=rate_limit,
                 while_offline=while_offline,
-                pool_size=args.pool_size)
+                pool_size=args.pool_size,
+                timeout=args.timeout)
         elif subcommand == 'wal-fetch':
             external_program_check([LZOP_BIN])
             res = backup_cxt.wal_restore(args.WAL_SEGMENT,

--- a/wal_e/operator/backup.py
+++ b/wal_e/operator/backup.py
@@ -171,11 +171,16 @@ class Backup(object):
         start_backup_info = None
         if 'while_offline' in kwargs:
             while_offline = kwargs.pop('while_offline')
+        if 'timeout' in kwargs:
+            timeout = kwargs.pop('timeout')
+        else:
+            timeout = None
 
+        pg_backup = PgBackupStatements(timeout)
         try:
             if not while_offline:
-                start_backup_info = PgBackupStatements.run_start_backup()
-                version = PgBackupStatements.pg_version()['version']
+                start_backup_info = pg_backup.run_start_backup()
+                version = pg_backup.pg_version()['version']
             else:
                 if os.path.exists(os.path.join(data_directory,
                                                'postmaster.pid')):
@@ -206,7 +211,7 @@ class Backup(object):
                             'See README: TODO about pg_cancel_backup'))
 
             if not while_offline:
-                stop_backup_info = PgBackupStatements.run_stop_backup()
+                stop_backup_info = pg_backup.run_stop_backup()
             else:
                 stop_backup_info = start_backup_info
             backup_stop_good = True


### PR DESCRIPTION
If you have a global statement_timeout on postgres, wal-e backup could timeout because it takes a while. This param would let you disable the timeout. Or set a really long one in case the backup was hanging for some reason.
