### PR TITLE
Deleting S3 keys works with Google Storage.

### DIFF
--- a/wal_e/worker/s3/s3_deleter.py
+++ b/wal_e/worker/s3/s3_deleter.py
@@ -1,3 +1,7 @@
+import os
+
+from boto.s3.connection import Key
+
 from wal_e import exception
 from wal_e import retries
 from wal_e.worker.base import _Deleter
@@ -24,4 +28,12 @@ class Deleter(_Deleter):
                     hint='This should be reported as a bug.')
 
         bucket = page[0].bucket
-        bucket.delete_keys([key.name for key in page])
+
+        impl = os.getenv('WALE_S3_ENDPOINT')
+        if impl and 'storage.googleapis.com' in impl:
+            for key in page:
+                k = Key(bucket)
+                k.key = key.name
+                bucket.delete_key(k)
+        else:
+            bucket.delete_keys([key.name for key in page])


### PR DESCRIPTION
This PR fixes s3_deleter.py to work with Google Storage interoperability API. The issue is Google's interoperability API doesn't seem to support multi delete of keys.

When we replaced the bucket.delete_keys with bucket.delete_key, we made the WAL-E's delete command work when WALE_S3_ENDPOINT points to GS.

See this issue for full explanation: https://github.com/wal-e/wal-e/issues/192