### PR TITLE
Remove deprecated/unimplemented -M argument for pip in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: $(VIRTUALENV)
 
 $(VIRTUALENV): requirements.txt
 	@virtualenv --no-site-packages $(VIRTUALENV)
-	@$(VIRTUALENV)/bin/pip install -M -r requirements.txt
+	@$(VIRTUALENV)/bin/pip install -r requirements.txt
 	$(PYTHON) setup.py develop
 	touch $(VIRTUALENV)
 


### PR DESCRIPTION
Remove the usage of the `-M` argument with pip in the Makefile. The option was deprecated in 1.5 and was fully removed in versions >= 7.0.0.