### PR TITLE
server side encryption defaulted to False

### DIFF
--- a/wal_e/blobstore/s3/s3_util.py
+++ b/wal_e/blobstore/s3/s3_util.py
@@ -52,7 +52,7 @@ def uri_put_file(creds, uri, fp, content_encoding=None, conn=None):
     if content_encoding is not None:
         k.content_type = content_encoding
 
-    k.set_contents_from_file(fp, encrypt_key=True)
+    k.set_contents_from_file(fp, encrypt_key=False)
     return k
 
 


### PR DESCRIPTION
1. S3 server side encryption (as opposed to client side encryption) requires additional changes to blobstore in order to properly handle SSE-S3 or SSE-KMS or SSE-C) 
  ref: http://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html
2. s3_util.py was "hardcoding" encrypt_key=True -- which enables server side encryption - although 
    client side encryption is expected to be True, we cannot expect the same of server side encryption.
3. this change was necessary for us to move forward with our use-case. 
---
that said, a proper support of server side encryption by WAL-e utils needs a bit more work before it is usable. In the meantime, it is perhaps incorrect to assume all users will have server-side encryption turned on. 
Please consider this PR. I can provide more details if needed. We are storing several TB of WAL's/base backups of postgres servers using WAL-e. We can think of covering the SSE-* properly in the next round.

Regards,
Venkat
