### PR TITLE
Explicitly ignore psqlrc when calling psql

### DIFF
--- a/wal_e/worker/pg/psql_worker.py
+++ b/wal_e/worker/pg/psql_worker.py
@@ -42,7 +42,7 @@ def psql_csv_run(sql_command, error_handler=None):
     csv_query = ['SET statement_timeout = 0']
     csv_query.append('COPY ({}) TO STDOUT WITH CSV HEADER'.format(sql_command))
 
-    psql_proc = popen_nonblock([PSQL_BIN, '-d', 'postgres', '--no-password',
+    psql_proc = popen_nonblock([PSQL_BIN, '--no-psqlrc', '-d', 'postgres', '--no-password',
                                 '-c', '; '.join(csv_query)],
                                stdout=PIPE)
     stdout = psql_proc.communicate()[0]

--- a/wal_e/worker/pg/psql_worker.py
+++ b/wal_e/worker/pg/psql_worker.py
@@ -42,8 +42,8 @@ def psql_csv_run(sql_command, error_handler=None):
     csv_query = ['SET statement_timeout = 0']
     csv_query.append('COPY ({}) TO STDOUT WITH CSV HEADER'.format(sql_command))
 
-    psql_proc = popen_nonblock([PSQL_BIN, '--no-psqlrc', '-d', 'postgres', '--no-password',
-                                '-c', '; '.join(csv_query)],
+    psql_proc = popen_nonblock([PSQL_BIN, '-d', 'postgres', '--no-password',
+                                '--no-psqlrc', '-c', '; '.join(csv_query)],
                                stdout=PIPE)
     stdout = psql_proc.communicate()[0]
 


### PR DESCRIPTION
A .psqlrc startup file may generate output.
As it is expected that no output is generated other than the CSV output,
it seems correct to ignore .psqlrc altogether.