### PR TITLE
Disable query timeout with PGOPTIONS.

### DIFF
--- a/wal_e/worker/pg/psql_worker.py
+++ b/wal_e/worker/pg/psql_worker.py
@@ -6,7 +6,7 @@ from subprocess import PIPE
 from wal_e.piper import popen_nonblock
 from wal_e.exception import UserException
 
-PSQL_BIN = 'psql'
+PSQL_BIN = 'PGOPTIONS="--statement-timeout=0" psql'
 
 
 class UTC(datetime.tzinfo):
@@ -38,8 +38,7 @@ def psql_csv_run(sql_command, error_handler=None):
     situations.  The output is fully buffered into Python.
 
     """
-    # Explicitly disable the query timeout.
-    csv_query = ['SET statement_timeout = 0']
+    csv_query = []
     csv_query.append('COPY ({}) TO STDOUT WITH CSV HEADER'.format(sql_command))
 
     psql_proc = popen_nonblock([PSQL_BIN, '-d', 'postgres', '--no-password',


### PR DESCRIPTION
TLDR: `SET statement_timeout = 0; COPY ...` does not work, because it sets timeout for next query.

Compare:

```
psql -c "set statement_timeout=1000; select pg_sleep(5)"
 pg_sleep 
----------
 
(1 row)
```

With:

```
PGOPTIONS="--statement-timeout=1s" psql -c "select pg_sleep(5000)"
ERROR:  canceling statement due to statement timeout
```

This explained in detail here http://dba.stackexchange.com/a/83035