### PR TITLE
Fix psql bin to pass environment as separate arg.

### DIFF
--- a/wal_e/worker/pg/psql_worker.py
+++ b/wal_e/worker/pg/psql_worker.py
@@ -6,7 +6,7 @@ from subprocess import PIPE
 from wal_e.piper import popen_nonblock
 from wal_e.exception import UserException
 
-PSQL_BIN = 'PGOPTIONS="--statement-timeout=0" psql'
+PSQL_BIN = 'psql'
 
 
 class UTC(datetime.tzinfo):
@@ -43,7 +43,8 @@ def psql_csv_run(sql_command, error_handler=None):
 
     psql_proc = popen_nonblock([PSQL_BIN, '-d', 'postgres', '--no-password',
                                 '--no-psqlrc', '-c', csv_query],
-                               stdout=PIPE)
+                               stdout=PIPE,
+                               env={'PGOPTIONS': '--statement-timeout=0'})
     stdout = psql_proc.communicate()[0]
 
     if psql_proc.returncode != 0:


### PR DESCRIPTION
My previous change in https://github.com/wal-e/wal-e/pull/230 was incorrect, because env vars should be passed separately. From docs https://docs.python.org/2/library/subprocess.html#subprocess.call

```
If env is not None, it must be a mapping that defines the environment variables for the new process; these are used instead of inheriting the current process’ environment, which is the default behavior.
```

This time I tested that it works for real :)