### PR TITLE
Skip unlinked files when creating tar partitions

### DIFF
--- a/wal_e/tar_partition.py
+++ b/wal_e/tar_partition.py
@@ -385,6 +385,7 @@ def _segmentation_guts(root, file_paths, max_partition_size):
                     logger.debug(
                         msg='tar member additions skipping an unlinked file',
                         detail='Skipping {0}.'.format(et_info.submitted_path))
+                    continue
                 else:
                     raise
 


### PR DESCRIPTION
Fixes #228. cc @fdr 

Continuing this iteration when the exception is raised leads to an
unknown state where et_info holds the information of the previous
iteration.
This leads to re-uploading the previous file whenever an unlinked file
is processed.

It is OK (the comment above the code states it too) to skip and let the
WAL replay those.

Minimal example:
```python
└─$  cat test.py
import errno
import os
import tarfile

paths = [
    "/home/leo/test", # This path exists and plays a regular PG file
    "/blah", # This path does not exist
]

bogus_tar = tarfile.TarFile(os.devnull, 'w', dereference=False)

for p in paths:
    try:
        t = bogus_tar.gettarinfo(p)
    except EnvironmentError, e:
        if (e.errno == errno.ENOENT and e.filename == p):
            print "boo %s" % p

    print t

└─$  python test.py
<TarInfo 'home/leo/test' at 0x7f68ee205750>
boo /blah
<TarInfo 'home/leo/test' at 0x7f68ee205750>
```