### PR TITLE
Fix excessive logging by wal-fetch when standby_mode=on

### DIFF
--- a/wal_e/blobstore/s3/s3_util.py
+++ b/wal_e/blobstore/s3/s3_util.py
@@ -125,7 +125,7 @@ def do_lzop_get(creds, url, path, decrypt, do_retry=True):
                         # Do not retry if the key not present, this
                         # can happen under normal situations.
                         pl.abort()
-                        logger.warning(
+                        logger.info(
                             msg=('could no longer locate object while '
                                  'performing wal restore'),
                             detail=('The absolute URI that could not be '


### PR DESCRIPTION
When running wal-fetch on slaves with standby_mode = on (in recovery.conf), log files fill up with this brain-dead message every 5 seconds, even when --terse mode is enabled:
```
wal_e.blobstore.s3.s3_util WARNING     MSG: could no longer locate object while performing wal restore
        DETAIL: The absolute URI that could not be located is s3://XXXXXXXX/XXXXXXXX/wal_005/00000001000000000000008A.lzo.
        HINT: This can be normal when Postgres is trying to detect what timelines are available during restoration.
        STRUCTURED: time=2016-04-25T09:52:04.977582-00 pid=22160
```
PR is a simple fix to log these messages at INFO level.

Note: I still get `lzop: <stdin>: not a lzop file` in the log file every 5 seconds, but this is a bit harder to fix properly because the pipeline code doesn't handle stderr at all. Workaround is to use a recovery.conf restore_command like this:
```
restore_command = 'AWS_REGION=xxxxxxx wal-e --s3-prefix=s3://xxxxxxx/xxxxx --terse --aws-instance-profile wal-fetch "%f" "%p" 2>&1 | egrep -v "not a lzop file"'
```

**EDIT**: restore_command workaround above is broken because postgresql will get egrep's exit status when it should get wal-e's exit status. Using this restore_command instead fixes that issue:

```bash
  restore_command = '. /etc/bashrc ; o="`AWS_REGION=xxxxxxx wal-e --terse --s3-prefix=s3://mybucket --aws-instance-profile wal-fetch "%f" "%p" 2>&1`" ; r=$? ; echo "$o" | egrep -v "not a lzop file" ; exit $r'
```