### PR TITLE
Fix a bug on Azure creating a top-level directory without a name.

### DIFF
--- a/wal_e/blobstore/wabs/wabs_util.py
+++ b/wal_e/blobstore/wabs/wabs_util.py
@@ -43,6 +43,11 @@ logger = log_help.WalELogger(__name__)
 _Key = collections.namedtuple('_Key', ['size'])
 WABS_CHUNK_SIZE = 4 * 1024 * 1024
 
+def strip_slash(path):
+    """Blob names are assumed to be relative paths, so names of the form
+    /path/to/file create a top-level directory with no name.  Let's not do
+    that."""
+    return path[1:] if path[0] == '/' else path
 
 def uri_put_file(creds, uri, fp, content_encoding=None):
     assert fp.tell() == 0
@@ -86,7 +91,7 @@ def uri_put_file(creds, uri, fp, content_encoding=None):
     @retry(retry_with_count(log_upload_failures_on_error))
     def upload_chunk(chunk, block_id):
         check_sum = base64.encodestring(md5(chunk).digest()).strip('\n')
-        conn.put_block(url_tup.netloc, url_tup.path, chunk,
+        conn.put_block(url_tup.netloc, strip_slash(url_tup.path), chunk,
                        block_id, content_md5=check_sum)
 
     url_tup = urlparse(uri)
@@ -97,7 +102,7 @@ def uri_put_file(creds, uri, fp, content_encoding=None):
     conn = BlobService(
         creds.account_name, creds.account_key,
         sas_token=creds.access_token, protocol='https')
-    conn.put_blob(url_tup.netloc, url_tup.path, '', **kwargs)
+    conn.put_blob(url_tup.netloc, strip_slash(url_tup.path), '', **kwargs)
 
     # WABS requires large files to be uploaded in 4MB chunks
     block_ids = []
@@ -117,7 +122,7 @@ def uri_put_file(creds, uri, fp, content_encoding=None):
             p.join()
             break
 
-    conn.put_block_list(url_tup.netloc, url_tup.path, block_ids)
+    conn.put_block_list(url_tup.netloc, strip_slash(url_tup.path), block_ids)
 
     # To maintain consistency with the S3 version of this function we must
     # return an object with a certain set of attributes.  Currently, that set
@@ -134,7 +139,7 @@ def uri_get_file(creds, uri, conn=None):
                            sas_token=creds.access_token, protocol='https')
 
     # Determin the size of the target blob
-    props = conn.get_blob_properties(url_tup.netloc, url_tup.path)
+    props = conn.get_blob_properties(url_tup.netloc, strip_slash(url_tup.path))
     blob_size = int(props['content-length'])
 
     ret_size = 0
@@ -150,7 +155,7 @@ def uri_get_file(creds, uri, conn=None):
             # whole file over again.
             try:
                 part = conn.get_blob(url_tup.netloc,
-                                     url_tup.path,
+                                     strip_slash(url_tup.path),
                                      x_ms_range=ms_range)
             except EnvironmentError as e:
                 if e.errno in (errno.EBUSY, errno.ECONNRESET):

--- a/wal_e/blobstore/wabs/wabs_util.py
+++ b/wal_e/blobstore/wabs/wabs_util.py
@@ -43,11 +43,13 @@ logger = log_help.WalELogger(__name__)
 _Key = collections.namedtuple('_Key', ['size'])
 WABS_CHUNK_SIZE = 4 * 1024 * 1024
 
+
 def strip_slash(path):
     """Blob names are assumed to be relative paths, so names of the form
     /path/to/file create a top-level directory with no name.  Let's not do
     that."""
     return path[1:] if path[0] == '/' else path
+
 
 def uri_put_file(creds, uri, fp, content_encoding=None):
     assert fp.tell() == 0

--- a/wal_e/worker/wabs/wabs_worker.py
+++ b/wal_e/worker/wabs/wabs_worker.py
@@ -33,7 +33,7 @@ class TarPartitionLister(object):
             self.backup_info)
 
         blob_list = self.wabs_conn.list_blobs(self.layout.store_name(),
-                                              prefix='/' + prefix)
+                                              prefix=prefix)
         for blob in blob_list.blobs:
             url = 'wabs://{container}/{name}'.format(
                 container=self.layout.store_name(), name=blob.name)
@@ -88,7 +88,7 @@ class BackupList(_BackupList):
 
     def _backup_list(self, prefix):
         blob_list = self.conn.list_blobs(self.layout.store_name(),
-                                         prefix='/' + prefix)
+                                         prefix=prefix)
         return blob_list.blobs
 
 
@@ -107,5 +107,5 @@ class DeleteFromContext(_DeleteFromContext):
 
     def _backup_list(self, prefix):
         blob_list = self.conn.list_blobs(self.layout.store_name(),
-                                         prefix='/' + prefix)
+                                         prefix=prefix)
         return blob_list.blobs


### PR DESCRIPTION
Azure assumes blob names have relative paths, and but urlparse creates an absolute path which azure interprets as a nameless top-level directory as seen in the screenshot:
![Azure Portal Screenshot](http://i.imgur.com/wXC89bq.png).  

This fixes that by stripping the leading / if necessary.