### PR TITLE
use _set_auth_region_name

### DIFF
--- a/wal_e/blobstore/s3/calling_format.py
+++ b/wal_e/blobstore/s3/calling_format.py
@@ -95,7 +95,7 @@ def _connect_secureish(*args, **kwargs):
     conn = connection.S3Connection(*args, **kwargs)
 
     if auth_region_name:
-        conn.auth_region_name = auth_region_name
+        conn._set_auth_region_name(auth_region_name)
 
     return conn
 


### PR DESCRIPTION
This function not only sets the parent class's auth_region_name, but also the auth_handler's
region_name.

See https://github.com/boto/boto/blob/abb38474ee5124bb571da0c42be67cd27c47094f/boto/connection.py#L593-L595