### PR TITLE
Remove Content-Encoding for _backup_stop_sentinel.json

### DIFF
--- a/wal_e/operator/backup.py
+++ b/wal_e/operator/backup.py
@@ -240,7 +240,7 @@ class Backup(object):
 
             uri_put_file(self.creds,
                          uploaded_to + '_backup_stop_sentinel.json',
-                         sentinel_content, content_encoding='application/json')
+                         sentinel_content)
         else:
             # NB: Other exceptions should be raised before this that
             # have more informative results, it is intended that this


### PR DESCRIPTION
Referencing issue https://github.com/wal-e/wal-e/issues/272

Removed set of `content_encoding` value (the default `None`) is sufficient for the filetype.