### PR TITLE
Changed content-encoding to content-type

### DIFF
--- a/wal_e/blobstore/gs/utils.py
+++ b/wal_e/blobstore/gs/utils.py
@@ -30,7 +30,7 @@ def _uri_to_blob(creds, uri, conn=None):
     return storage.Blob(url_tup.path, b)
 
 
-def uri_put_file(creds, uri, fp, content_encoding=None, conn=None):
+def uri_put_file(creds, uri, fp, content_type=None, conn=None):
     assert fp.tell() == 0
     blob = _uri_to_blob(creds, uri, conn=conn)
 
@@ -39,7 +39,7 @@ def uri_put_file(creds, uri, fp, content_encoding=None, conn=None):
 
     fp.seek(0, 0)
     blob.upload_from_file(fp, num_retries=0, size=size,
-                          content_type=content_encoding)
+                          content_type=content_type)
     return blob
 
 

--- a/wal_e/blobstore/s3/s3_util.py
+++ b/wal_e/blobstore/s3/s3_util.py
@@ -38,7 +38,7 @@ def _uri_to_key(creds, uri, conn=None):
     return boto.s3.key.Key(bucket=bucket, name=url_tup.path)
 
 
-def uri_put_file(creds, uri, fp, content_encoding=None, conn=None):
+def uri_put_file(creds, uri, fp, content_type=None, conn=None):
     # Per Boto 2.2.2, which will only read from the current file
     # position to the end.  This manifests as successfully uploaded
     # *empty* keys in S3 instead of the intended data because of how
@@ -51,8 +51,8 @@ def uri_put_file(creds, uri, fp, content_encoding=None, conn=None):
 
     k = _uri_to_key(creds, uri, conn=conn)
 
-    if content_encoding is not None:
-        k.content_type = content_encoding
+    if content_type is not None:
+        k.content_type = content_type
 
     k.set_contents_from_file(fp, encrypt_key=True)
     return k

--- a/wal_e/blobstore/swift/utils.py
+++ b/wal_e/blobstore/swift/utils.py
@@ -24,7 +24,7 @@ class SwiftKey(object):
         self.last_modified = last_modified
 
 
-def uri_put_file(creds, uri, fp, content_encoding=None):
+def uri_put_file(creds, uri, fp, content_type=None):
     assert fp.tell() == 0
     assert uri.startswith('swift://')
 
@@ -34,7 +34,7 @@ def uri_put_file(creds, uri, fp, content_encoding=None):
     conn = calling_format.connect(creds)
 
     conn.put_object(
-        container_name, url_tup.path, fp, content_type=content_encoding
+        container_name, url_tup.path, fp, content_type=content_type
     )
     # Swiftclient doesn't return us the total file size, we see how much of the
     # file swiftclient read in order to determine the file size.

--- a/wal_e/blobstore/wabs/wabs_util.py
+++ b/wal_e/blobstore/wabs/wabs_util.py
@@ -45,7 +45,7 @@ _Key = collections.namedtuple('_Key', ['size'])
 WABS_CHUNK_SIZE = 4 * 1024 * 1024
 
 
-def uri_put_file(creds, uri, fp, content_encoding=None):
+def uri_put_file(creds, uri, fp, content_type=None):
     assert fp.tell() == 0
     assert uri.startswith('wabs://')
 
@@ -92,8 +92,8 @@ def uri_put_file(creds, uri, fp, content_encoding=None):
 
     url_tup = urlparse(uri)
     kwargs = dict(x_ms_blob_type='BlockBlob')
-    if content_encoding is not None:
-        kwargs['x_ms_blob_content_encoding'] = content_encoding
+    if content_type is not None:
+        kwargs['x_ms_blob_content_type'] = content_type
 
     conn = BlobService(
         creds.account_name, creds.account_key,

--- a/wal_e/operator/backup.py
+++ b/wal_e/operator/backup.py
@@ -240,7 +240,7 @@ class Backup(object):
 
             uri_put_file(self.creds,
                          uploaded_to + '_backup_stop_sentinel.json',
-                         sentinel_content, content_encoding='application/json')
+                         sentinel_content, content_type='application/json')
         else:
             # NB: Other exceptions should be raised before this that
             # have more informative results, it is intended that this
@@ -484,7 +484,7 @@ class Backup(object):
                     .format(extended_version_url=extended_version_url)))
         uri_put_file(self.creds,
                      extended_version_url, StringIO(version),
-                     content_encoding='text/plain')
+                     content_type='text/plain')
 
         logger.info(msg='postgres version metadata upload complete')
 

--- a/wal_e/worker/worker_util.py
+++ b/wal_e/worker/worker_util.py
@@ -7,10 +7,10 @@ from wal_e.blobstore import get_blobstore
 from wal_e import pipeline
 
 
-def uri_put_file(creds, uri, fp, content_encoding=None):
+def uri_put_file(creds, uri, fp, content_type=None):
     blobstore = get_blobstore(storage.StorageLayout(uri))
     return blobstore.uri_put_file(creds, uri, fp,
-                                  content_encoding=content_encoding)
+                                  content_type=content_type)
 
 
 def do_lzop_put(creds, url, local_path, gpg_key):


### PR DESCRIPTION
Referencing suggestion by @fdr from https://github.com/wal-e/wal-e/pull/273; removed re-interpretation of `content-encoding` value as `content-type`.

Fixed Windows Azure blobstore header name to match.