### PR TITLE
Allow PARTITION_MAX_SZ to be tunable

### DIFF
--- a/wal_e/tar_partition.py
+++ b/wal_e/tar_partition.py
@@ -139,7 +139,7 @@ ExtendedTarInfo = collections.namedtuple('ExtendedTarInfo',
 
 # 1.5 GiB is 1610612736 bytes, and Postgres allocates 1 GiB files as a
 # nominal maximum.  This must be greater than that.
-PARTITION_MAX_SZ = 1610612736
+PARTITION_MAX_SZ = int(os.environ.get('WALE_PARTITION_MAX_SZ', '1610612736'))
 
 # Maximum number of members in a TarPartition segment.
 #


### PR DESCRIPTION
We are running into the issue that we have files stored in our PGDATA which
are larger than 1GB.
Previously this issue was reported in https://groups.google.com/forum/#!topic/wal-e/fg94jVdiSOo.
This change makes this value configurable, which would suit our purposes.
