### PR TITLE
Fix TypeError

### DIFF
--- a/wal_e/operator/backup.py
+++ b/wal_e/operator/backup.py
@@ -7,7 +7,7 @@ import json
 import os
 import sys
 
-from io import StringIO
+from io import StringIO, BytesIO
 from wal_e import log_help
 from wal_e import storage
 from wal_e import tar_partition
@@ -483,7 +483,7 @@ class Backup(object):
             detail=('Uploading to {extended_version_url}.'
                     .format(extended_version_url=extended_version_url)))
         uri_put_file(self.creds,
-                     extended_version_url, StringIO(version),
+                     extended_version_url, BytesIO(version.encode('utf-8')),
                      content_type='text/plain')
 
         logger.info(msg='postgres version metadata upload complete')


### PR DESCRIPTION
uri_put_file function expects a BytesIO binary stream to be passed. It chunks the file and uploads it to blobstore. It also calculates the md5 hash for the chunks for data integrity while uploading. Passing StringIO text stream was resulting in a TypeError when doing a md5 checksum of string chunk. This fixes #277 

I have tested this with Azure Storage and python 3.4