### PR TITLE
Support --aws-instance-profile with an environment variable

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,6 +2,7 @@ Alex Gaynor <alex.gaynor@gmail.com>
 Anatolii Mihailenco <anmic.webdev@gmail.com>
 Andrew Marks <amarks@gmail.com>
 Andrew Williams <awilliams@intoxitrack.net>
+Andy Freeland <andy@andyfreeland.net>
 Ayush Goyal <ayush@helpshift.com>
 Bartek Jarocki <bartek@smatly.com>
 Bo Shi <bs@alum.mit.edu>

--- a/tests/gs_integration_help.py
+++ b/tests/gs_integration_help.py
@@ -6,6 +6,8 @@ import json
 import os
 import pytest
 
+from wal_e.cmd import parse_boolean_envvar
+
 
 MANGLE_SUFFIX = None
 
@@ -31,7 +33,8 @@ def no_real_gs_credentials():
 
     Phrased in the negative to make it read better with 'skipif'.
     """
-    if os.getenv('WALE_GS_INTEGRATION_TESTS') != 'TRUE':
+    if parse_boolean_envvar(
+            os.getenv('WALE_GS_INTEGRATION_TESTS')) is not True:
         return True
 
     if os.getenv('GOOGLE_APPLICATION_CREDENTIALS') is None:

--- a/tests/s3_integration_help.py
+++ b/tests/s3_integration_help.py
@@ -7,6 +7,7 @@ from boto import sts
 from boto.s3.connection import Location
 from wal_e.blobstore import s3
 from wal_e.blobstore.s3 import calling_format
+from wal_e.cmd import parse_boolean_envvar
 
 
 def bucket_name_mangle(bn, delimiter='-'):
@@ -18,7 +19,8 @@ def no_real_s3_credentials():
 
     Phrased in the negative to make it read better with 'skipif'.
     """
-    if os.getenv('WALE_S3_INTEGRATION_TESTS') != 'TRUE':
+    if parse_boolean_envvar(os.getenv(
+            'WALE_S3_INTEGRATION_TESTS')) is not True:
         return True
 
     for e_var in ('AWS_ACCESS_KEY_ID',

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,0 +1,17 @@
+import pytest
+
+from wal_e.cmd import parse_boolean_envvar
+
+
+@pytest.mark.parametrize('val,expected', [
+    ('1', True),
+    ('TRUE', True),
+    ('true', True),
+    (None, False),
+    ('', False),
+    ('0', False),
+    ('FALSE', False),
+    ('false', False),
+])
+def test_parse_boolean_envvar(val, expected):
+    assert parse_boolean_envvar(val) == expected

--- a/tests/wabs_integration_help.py
+++ b/tests/wabs_integration_help.py
@@ -9,13 +9,16 @@ except ImportError:
 
 import os
 
+from wal_e.cmd import parse_boolean_envvar
+
 
 def no_real_wabs_credentials():
     """Helps skip integration tests without live credentials.
 
     Phrased in the negative to make it read better with 'skipif'.
     """
-    if os.getenv('WALE_WABS_INTEGRATION_TESTS') != 'TRUE':
+    if parse_boolean_envvar(os.getenv(
+            'WALE_WABS_INTEGRATION_TESTS')) is not True:
         return True
 
     for e_var in ('WABS_ACCOUNT_NAME', 'WABS_ACCESS_KEY'):

--- a/wal_e/cmd.py
+++ b/wal_e/cmd.py
@@ -162,6 +162,16 @@ def extract_segment(text_with_extractable_segment):
         return SegmentNumber(log=groupdict['log'], seg=groupdict['seg'])
 
 
+def parse_boolean_envvar(val):
+    """Parse a boolean environment variable."""
+    if not val or val.lower() in {'false', '0'}:
+        return False
+    elif val.lower() in {'true', '1'}:
+        return True
+    else:
+        raise ValueError('Invalid boolean environment variable: %s' % val)
+
+
 def build_parser():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -461,7 +471,7 @@ def configure_backup_cxt(args):
     # 'operator.Backup' protocol.
     if store.is_s3:
         use_instance_profile = args.aws_instance_profile or \
-            os.getenv('AWS_INSTANCE_PROFILE', '').lower() in ('true', '1')
+            parse_boolean_envvar(os.getenv('AWS_INSTANCE_PROFILE'))
         if use_instance_profile:
             creds = s3_instance_profile()
         else:


### PR DESCRIPTION
This patch enables configuring `--aws-instance-profile` by setting an environment variable `AWS_INSTANCE_PROFILE=1`. Currently, this is the only AWS option that cannot be configured through an environment variable and this allows all configuration to be through envdir or similar.

Fixes #287.
