### PR TITLE
Support for more authentication variables in Swift

### DIFF
--- a/wal_e/blobstore/swift/calling_format.py
+++ b/wal_e/blobstore/swift/calling_format.py
@@ -13,6 +13,10 @@ def connect(creds):
         tenant_name=creds.tenant_name,
         os_options={
             "region_name": creds.region,
-            "endpoint_type": creds.endpoint_type
+            "endpoint_type": creds.endpoint_type,
+            "domain_id": creds.domain_id,
+            "tenant_id": creds.tenant_id,
+            "user_id": creds.user_id,
+            "user_domain_id": creds.user_domain_id,
         }
     )

--- a/wal_e/blobstore/swift/credentials.py
+++ b/wal_e/blobstore/swift/credentials.py
@@ -1,6 +1,7 @@
 class Credentials(object):
     def __init__(self, authurl, user, password, tenant_name, region,
-            endpoint_type, auth_version):
+            endpoint_type, auth_version, domain_id, tenant_id, user_id,
+            user_domain_id):
         self.authurl = authurl
         self.user = user
         self.password = password
@@ -8,3 +9,7 @@ class Credentials(object):
         self.region = region
         self.endpoint_type = endpoint_type
         self.auth_version = auth_version
+        self.domain_id = domain_id
+        self.tenant_id = tenant_id
+        self.user_id = user_id
+        self.user_domain_id = user_domain_id

--- a/wal_e/cmd.py
+++ b/wal_e/cmd.py
@@ -505,6 +505,10 @@ def configure_backup_cxt(args):
             os.getenv('SWIFT_REGION'),
             os.getenv('SWIFT_ENDPOINT_TYPE', 'publicURL'),
             os.getenv('SWIFT_AUTH_VERSION', '2'),
+            os.getenv('SWIFT_DOMAIN_ID'),
+            os.getenv('SWIFT_TENANT_ID'),
+            os.getenv('SWIFT_USER_ID'),
+            os.getenv('SWIFT_USER_DOMAIN_ID'),
         )
         return SwiftBackup(store, creds, gpg_key_id)
     elif store.is_gs:


### PR DESCRIPTION
`SWIFT_AUTH_VERSION` 3 usually uses more parameters to authenticate