### PR TITLE
Use new google cloud client package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ will attempt to resolve them:
 * gevent>=1.1.1
 * boto>=2.40.0
 * azure>=1.0.3
-* gcloud>=0.17.0
+* google-cloud-storage>=0.22.0
 * python-swiftclient>=3.0.0
 * python-keystoneclient>=3.0.0
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     extras_require={
         'aws': ['boto>=2.40.0'],
         'azure': ['azure>=1.0.3'],
-        'google': ['gcloud>=0.17.0'],
+        'google': ['google-cloud-storage>=0.22.0'],
         'swift': ['python-swiftclient>=3.0.0',
                   'python-keystoneclient>=3.0.0']
     },

--- a/tests/gs_integration_help.py
+++ b/tests/gs_integration_help.py
@@ -1,5 +1,5 @@
-from gcloud import exceptions
-from gcloud import storage
+from google.cloud import exceptions
+from google.cloud import storage
 import base64
 import hmac
 import json

--- a/tests/test_gs_deleter.py
+++ b/tests/test_gs_deleter.py
@@ -4,7 +4,7 @@ import pytest
 from gevent import lock
 
 from fast_wait import fast_wait
-from gcloud import storage
+from google.cloud import storage
 from wal_e import exception
 from wal_e.worker.gs import gs_deleter
 
@@ -58,7 +58,7 @@ def collect(monkeypatch):
     """Instead of performing bulk delete, collect blob names deleted.
 
     This is to test invariants, as to ensure deleted blobs are passed
-    to gcloud properly.
+    to google cloud properly.
     """
 
     collect = BucketDeleteBlobsCollector()

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
      azure-storage==0.20.3
      azure==1.0.3
      boto==2.40.0
-     gcloud==0.17.0
+     google-cloud-storage==0.22.0
      gevent==1.1.1
      python-keystoneclient==3.0.0
      python-swiftclient==3.0.0
@@ -19,7 +19,7 @@ deps =
     # All optional cloud dependencies.
     boto
     azure
-    gcloud
+    google-cloud-storage
     python-keystoneclient
     python-swiftclient
     {[base]deps}
@@ -29,7 +29,7 @@ deps =
     # All optional cloud dependencies.
     boto
     azure
-    gcloud
+    google-cloud-storage
     python-keystoneclient
     python-swiftclient
     {[base]deps}

--- a/wal_e/blobstore/gs/__init__.py
+++ b/wal_e/blobstore/gs/__init__.py
@@ -1,11 +1,11 @@
 try:
-    import gcloud
-    assert gcloud
+    import google.cloud
+    assert google.cloud
 except ImportError:
     from wal_e.exception import UserException
     raise UserException(
-        msg='Google support requires the module "gcloud" ',
-        hint='Try running "pip install gcloud')
+        msg='Google support requires the module "google-cloud-storage" ',
+        hint='Try running "pip install google-cloud-storage')
 
 from wal_e.blobstore.gs.credentials import Credentials
 from wal_e.blobstore.gs.utils import (

--- a/wal_e/blobstore/gs/credentials.py
+++ b/wal_e/blobstore/gs/credentials.py
@@ -1,4 +1,4 @@
 class Credentials(object):
-    # Rely on default gcloud client credential resolution instead of
-    # reifying credentials in WAL-E.
+    # Rely on default google cloud client credential resolution
+    # instead of reifying credentials in WAL-E.
     pass

--- a/wal_e/blobstore/gs/utils.py
+++ b/wal_e/blobstore/gs/utils.py
@@ -9,7 +9,7 @@ import urllib.request
 from . import calling_format
 from datetime import datetime
 from datetime import timedelta
-from gcloud import storage
+from google.cloud import storage
 from urllib.parse import urlparse
 from wal_e import files
 from wal_e import log_help


### PR DESCRIPTION
The old gcloud package has been deprecated. The new package also has a
somewhat better implementation to handle authenticated http calls and
hopefully in the future allows us to throw away the monkey patching of
httplib2 completely.