### PR TITLE
Add python36 to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,16 @@ deps =
     python-swiftclient
     {[base]deps}
 
+[testenv:py36]
+deps =
+    # All optional cloud dependencies.
+    boto
+    azure
+    google-cloud-storage
+    python-keystoneclient
+    python-swiftclient
+    {[base]deps}
+
 [base]
 deps =
     pytest


### PR DESCRIPTION
`brew install python3` installs python 3.6; so adding py36 to tox.ini