### PR TITLE
Stop downloading wal if the security token expired

### DIFF
--- a/wal_e/blobstore/s3/s3_util.py
+++ b/wal_e/blobstore/s3/s3_util.py
@@ -135,6 +135,18 @@ def do_lzop_get(creds, url, path, decrypt, do_retry=True):
                                   'during restoration.'))
                         decomp_out.remove_regardless = True
                         return False
+                    elif e.value.error_code == 'ExpiredToken':
+                        # Do not retry if STS token has expired.
+                        pl.abort()
+                        logger.info(
+                            msg=('could no longer authenticate while '
+                                 'performing wal restore'),
+                            detail=('The absolute URI that could not be '
+                                    'accessed is {url}.'.format(url=url)),
+                            hint=('This can be normal when using STS '
+                                  'credentials.'))
+                        decomp_out.remove_regardless = True
+                        return False
                     else:
                         raise
 


### PR DESCRIPTION
This prevent wal-e to try downloading wal indefinitely if the AWS security token expired. 

See #314