### PR TITLE
Don't backup recovery.done

### DIFF
--- a/wal_e/tar_partition.py
+++ b/wal_e/tar_partition.py
@@ -58,6 +58,7 @@ logger = log_help.WalELogger(__name__)
 PG_CONF = ('postgresql.conf',
            'pg_hba.conf',
            'recovery.conf',
+           'recovery.done',
            'pg_ident.conf',
            'promote')
 


### PR DESCRIPTION
The recovery.done file is not necessary to restore a backup and it might
contain a sensitive replication password from the former leader of the
cluster that is being backed up.

This commit adds recovery.done to PG_CONF so that it may be ignored when
excuting a backup-push.