### PR TITLE
Remove boto plugin removal from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 dist: trusty
+env:
+    # do not load /etc/boto.cfg with Python 3 incompatible plugin
+    # https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882
+    - BOTO_CONFIG=/doesnotexist
 python:
   - "3.4"
   - "3.5"
@@ -7,7 +11,6 @@ python:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libevent-dev lzop pv gnupg
-  - sudo rm /usr/share/google/boto/boto_plugins/*
 install: pip install tox-travis
 script: tox
 notifications:

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
     pytest-xdist
 
 [testenv]
-passenv = WALE_* AWS_* WABS_* GOOGLE_* SWIFT_*
+passenv = BOTO_CONFIG WALE_* AWS_* WABS_* GOOGLE_* SWIFT_*
 deps = {[base]deps}
 commands =
     pip install -e .


### PR DESCRIPTION
    As of late, the `rm` command fails.  Accomplish something similar via
    the advice in https://github.com/travis-ci/travis-ci/issues/5246.