### PR TITLE
Adds error handling to symlink workaround

### DIFF
--- a/wal_e/tar_partition.py
+++ b/wal_e/tar_partition.py
@@ -285,7 +285,14 @@ class TarPartition(list):
             # https://bugs.python.org/issue12800
             if member.issym():
                 target_path = os.path.join(dest_path, member.name)
-                os.symlink(member.linkname, target_path)
+                try:
+                    os.symlink(member.linkname, target_path)
+                except OSError as e:
+                    if e.errno == errno.EEXIST:
+                        os.remove(target_path)
+                        os.symlink(member.linkname, target_path)
+                    else:
+                        raise
                 continue
 
             if member.isreg() and member.size >= pipebuf.PIPE_BUF_BYTES:


### PR DESCRIPTION
Commit 0f9cd8b1cae2e3509f1643d314bf50f8662c09be added some necessary
handling of symbolic links that would otherwise force a TarFile to
falsely report as _loaded, preventing later files from being extracted.

However, creating a symlink does not follow the same overwrite
semanitics as writing a file does. Due to this, if a symlink already
exists, say, at `/database/pg_xlog`, and the basebackup attempts to
blindly create a new symlink, the syscall will fail with EEXIST:

```
670043 16:30:14.787274275 1 wal-e (8676) < symlink res=-17(EEXIST) target=/wal/pg_xlog linkpath=/database/pg_xlog
```

Oddly, this failure does not seem to crash wal-e and the process instead
waits, with the above being the last syscall it makes.

This patch adds a try and except block that will rescue a OSError of
type EEXIST, unlink the target filename and then create the symlink. In
practice, this allows a basebackup to be properly extracted without
hangs in a test environment.