### PR TITLE
Upgrade google-cloud-storage.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     extras_require={
         'aws': ['boto>=2.40.0'],
         'azure': ['azure>=1.0.3'],
-        'google': ['google-cloud-storage>=0.22.0'],
+        'google': ['google-cloud-storage>=1.4.0'],
         'swift': ['python-swiftclient>=3.0.0',
                   'python-keystoneclient>=3.0.0']
     },

--- a/wal_e/blobstore/gs/calling_format.py
+++ b/wal_e/blobstore/gs/calling_format.py
@@ -1,36 +1,10 @@
-from google.cloud.storage._http import Connection
-from google.cloud.credentials import get_credentials
 from google.cloud import storage
-from google.auth.credentials import with_scopes_if_required
-import google_auth_httplib2
-
-from gevent.local import local
-
 
 def connect(creds):
     """Construct a connection value to Google Storage API
 
-    The credentials are retrieved using get_credentials that checks
-    the environment for the correct values.
+    The credentials are retrieved using the default method which inspects the
+    GOOGLE_APPLICATION_CREDENTIALS environment variable.
 
     """
-    credentials = get_credentials()
-    return storage.Client(credentials=credentials,
-                          http=ThreadSafeHttp(credentials))
-
-
-class ThreadSafeHttp(object):
-
-    __scoped_credentials = None
-    __local = local()
-
-    def __init__(self, creds):
-        self.__scoped_credentials = with_scopes_if_required(
-            creds, Connection.SCOPE)
-
-    def __getattr__(self, name):
-        if not hasattr(self.__local, 'http'):
-            self.__local.http = google_auth_httplib2.AuthorizedHttp(
-                self.__scoped_credentials)
-
-        return getattr(self.__local.http, name)
+    return storage.Client()

--- a/wal_e/worker/gs/gs_worker.py
+++ b/wal_e/worker/gs/gs_worker.py
@@ -74,10 +74,8 @@ class BackupFetcher(object):
             hint='The absolute GCS object is {0}.'.format(part_abs_name))
 
         blob = self.bucket.get_blob('/' + part_abs_name)
-        signed = blob.generate_signed_url(datetime.datetime.utcnow() +
-                                          datetime.timedelta(minutes=10))
         with get_download_pipeline(PIPE, PIPE, self.decrypt) as pl:
-            g = gevent.spawn(gs.write_and_return_error, signed, pl.stdin)
+            g = gevent.spawn(gs.write_and_return_error, blob, pl.stdin)
             TarPartition.tarfile_extract(pl.stdout, self.local_root)
 
             # Raise any exceptions guarded by write_and_return_error.


### PR DESCRIPTION
I was running into https://github.com/GoogleCloudPlatform/google-cloud-python/issues/2949 with google-cloud-storage v0.22.0.

The newer version of google-cloud-storage has a stable API and uses requests
instead of httplib2. The latter should help with thread safety issues during
long transfers.