### PR TITLE
Fix tests for python 3.6

### DIFF
--- a/tests/test_log_help.py
+++ b/tests/test_log_help.py
@@ -15,7 +15,7 @@ def test_nonexisting_socket(tmpdir, monkeypatch):
     # Must not raise an exception, silently failing is preferred for
     # now.
     monkeypatch.setattr(log_help, 'HANDLERS', [])
-    log_help.configure(syslog_address=tmpdir.join('bogus'))
+    log_help.configure(syslog_address=str(tmpdir.join('bogus')))
 
 
 def test_format_structured_info(monkeypatch):


### PR DESCRIPTION
SyslogHandler now assumes the address to be either a string or a tuple
of host and port. For this reason we need to make sure we pass in a
string instead of an object.

Related commit in cpython:
https://github.com/python/cpython/commit/0b4b57df964f1ba427684556b8e5f05852454e0d