### PR TITLE
Updated README to correctly state default '--pool-size'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -608,8 +608,10 @@ One can instruct WAL-E to pool WAL segments together and send them in
 groups by passing the ``--pool-size`` parameter to ``wal-push``.  This
 can increase throughput significantly.
 
-As of version 0.7.x, ``--pool-size`` defaults to 8.
+As of version 1.x, ``--pool-size`` defaults to 32.
 
+Note: You can also use this parameter when calling ``backup-fetch``
+and ``backup-push`` (it defaults to 4).
 
 Using AWS IAM Instance Profiles
 '''''''''''''''''''''''''''''''


### PR DESCRIPTION
I might be wrong, but just in case I'm not, I _think_ the actual default value of `--pool-size` is 4, and not the 8 stated in the README:

https://github.com/wal-e/wal-e/blob/8d1eefba556d9e9f160ada2dc0b39a062b4e70b6/wal_e/cmd.py#L246-L248