### PR TITLE
Do not monkey patch on Python >= 3.6

### DIFF
--- a/wal_e/cmd.py
+++ b/wal_e/cmd.py
@@ -614,7 +614,8 @@ def main():
         backup_cxt = configure_backup_cxt(args)
 
         if subcommand == 'backup-fetch':
-            monkeypatch_tarfile_copyfileobj()
+            if (sys.version_info.major < 3 or (sys.version_info.major == 3 and sys.version_info.minor < 6)):
+                monkeypatch_tarfile_copyfileobj()
 
             external_program_check([LZOP_BIN])
             backup_cxt.database_fetch(
@@ -626,7 +627,8 @@ def main():
         elif subcommand == 'backup-list':
             backup_cxt.backup_list(query=args.QUERY, detail=args.detail)
         elif subcommand == 'backup-push':
-            monkeypatch_tarfile_copyfileobj()
+            if (sys.version_info.major < 3 or (sys.version_info.major == 3 and sys.version_info.minor < 6)):
+                monkeypatch_tarfile_copyfileobj()
 
             if args.while_offline:
                 # we need to query pg_config first for the


### PR DESCRIPTION
Hello,
 I took the patch from the comments on issue #322 but tweaked the logic a bit since as written it would have broken under a hypothetical python 4.0. I installed and tested locally under Python 3.6, but I don't have other python versions handy to test with. 