### PR TITLE
Make copyfileobj Python 3.6 compatible

### DIFF
--- a/wal_e/copyfileobj.py
+++ b/wal_e/copyfileobj.py
@@ -3,22 +3,23 @@ import shutil
 from wal_e import pipebuf
 
 
-def copyfileobj(src, dst, length=None, exception=OSError):
+def copyfileobj(src, dst, length=None, exception=OSError, bufsize=None):
     """Copy length bytes from fileobj src to fileobj dst.
        If length is None, copy the entire content.
     """
-    BUFSIZE = pipebuf.PIPE_BUF_BYTES
+    if bufsize is None:
+        bufsize = pipebuf.PIPE_BUF_BYTES
 
     if length == 0:
         return
     if length is None:
-        shutil.copyfileobj(src, dst, BUFSIZE)
+        shutil.copyfileobj(src, dst, bufsize)
         return
 
-    blocks, remainder = divmod(length, BUFSIZE)
+    blocks, remainder = divmod(length, bufsize)
     for b in range(blocks):
-        buf = src.read(BUFSIZE)
-        if len(buf) < BUFSIZE:
+        buf = src.read(bufsize)
+        if len(buf) < bufsize:
             raise exception("unexpected end of data")
         dst.write(buf)
 


### PR DESCRIPTION
Instead of weird version checks I've updated the `copyfileobj` to make it compatible with Python 3.6. The change fixes both keyword argument issue and use of an appropriate `bufsize` mentioned by @fdr.

Fixes #322
Fixes #376 
Fixes #380