### PR TITLE
AWS S3 Available regions and names update at 11 May 2018. 

### DIFF
--- a/wal_e/blobstore/s3/calling_format.py
+++ b/wal_e/blobstore/s3/calling_format.py
@@ -11,15 +11,24 @@ logger = log_help.WalELogger(__name__)
 
 _S3_REGIONS = {
     # See http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-    'ap-northeast-1': 's3-ap-northeast-1.amazonaws.com',
-    'ap-southeast-1': 's3-ap-southeast-1.amazonaws.com',
-    'ap-southeast-2': 's3-ap-southeast-2.amazonaws.com',
-    'eu-central-1': 's3-eu-central-1.amazonaws.com',
-    'eu-west-1': 's3-eu-west-1.amazonaws.com',
-    'sa-east-1': 's3-sa-east-1.amazonaws.com',
-    'us-east-1': 's3.amazonaws.com',
-    'us-west-1': 's3-us-west-1.amazonaws.com',
-    'us-west-2': 's3-us-west-2.amazonaws.com',
+    'ap-northeast-1': 's3.ap-northeast-1.amazonaws.com',
+    'ap-northeast-2': 's3.ap-northeast-2.amazonaws.com',
+    'ap-northeast-3': 's3.ap-northeast-3.amazonaws.com',
+    'ap-south-1': 's3.ap-south-1.amazonaws.com',
+    'ap-southeast-1': 's3.ap-southeast-1.amazonaws.com',
+    'ap-southeast-2': 's3.ap-southeast-2.amazonaws.com',
+    'ca-central-1': 's3.ca-central-1.amazonaws.com',
+    'cn-north-1': 's3.cn-north-1.amazonaws.com.cn',
+    'cn-northwest-1': 's3.cn-northwest-1.amazonaws.com.cn',
+    'eu-central-1': 's3.eu-central-1.amazonaws.com',
+    'eu-west-1': 's3.eu-west-1.amazonaws.com',
+    'eu-west-2': 's3.eu-west-2.amazonaws.com',
+    'eu-west-3': 's3.eu-west-3.amazonaws.com',
+    'sa-east-1': 's3.sa-east-1.amazonaws.com',
+    'us-east-1': 's3.us-east-1.amazonaws.com',
+    'us-east-2': 's3.us-east-2.amazonaws.com',
+    'us-west-1': 's3.us-west-1.amazonaws.com',
+    'us-west-2': 's3.us-west-2.amazonaws.com',
 }
 
 try:


### PR DESCRIPTION
Please see https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region.
I'm just lacking of us-east-2 but performed update accordingly current state of things.