### PR TITLE
Fix extraction of gevent version in test

### DIFF
--- a/tests/test_channel_shim.py
+++ b/tests/test_channel_shim.py
@@ -5,7 +5,7 @@ from wal_e import channel
 
 
 def test_channel_shim():
-    v = tuple(int(x) for x in gevent.__version__.split('.'))
+    v = tuple(int(x) for x in gevent.__version__.split('.')[:2])
     print('Version info:', gevent.__version__, v)
 
     if v >= (0, 13) and v < (1, 0):


### PR DESCRIPTION
Current version of gevent installed in travis seems to have a ".post0" as the last part of the version, which fails the integer conversion. Since we are only interested in the first two parts of the version anyway we can just strip the rest away.