### PR TITLE
Allow to disable S3 SSE for custom providers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -655,6 +655,10 @@ Example::
 
   # As seen when using Deis, which uses radosgw.
   WALE_S3_ENDPOINT=http+path://deis-store-gateway:8888
+  
+Some S3-compatible providers doesn't fully support `Server-Side Encryption`_. In this case you can disable encryption by setting ``WALE_S3_SSE`` environment variable to ``False|false|0``.
+
+.. _Server-Side Encryption: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html
 
 Development
 -----------

--- a/wal_e/blobstore/s3/s3_util.py
+++ b/wal_e/blobstore/s3/s3_util.py
@@ -3,6 +3,7 @@ import gevent
 import os
 import socket
 import traceback
+from distutils.util import strtobool
 
 import boto
 
@@ -54,7 +55,8 @@ def uri_put_file(creds, uri, fp, content_type=None, conn=None):
     if content_type is not None:
         k.content_type = content_type
 
-    k.set_contents_from_file(fp, encrypt_key=True)
+    sse = os.getenv('WALE_S3_SSE', default='True')
+    k.set_contents_from_file(fp, encrypt_key=strtobool(sse))
     return k
 
 


### PR DESCRIPTION
Some S3-compatible providers (like DigitalOcean Spaces) doesn't support SSE. For now wal-e [turns encryption on by default](https://github.com/wal-e/wal-e/blob/master/wal_e/blobstore/s3/s3_util.py#L57). This PR makes it configurable via env variable.