### PR TITLE
Add new environ variable for s3 storage class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,8 @@ AWS S3 and Work-alikes
 Optional:
 
 * WALE_S3_ENDPOINT: See `Manually specifying the S3 Endpoint`_
+* WALE_S3_STORAGE_CLASS: One of: STANDARD (default), REDUCED_REDUNDANCY,
+  GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE
 * AWS_SECURITY_TOKEN: When using AWS STS
 * Pass ``--aws-instance-profile`` to gather credentials from the
   Instance Profile.  See `Using AWS IAM Instance Profiles`.

--- a/wal_e/blobstore/s3/s3_util.py
+++ b/wal_e/blobstore/s3/s3_util.py
@@ -54,7 +54,8 @@ def uri_put_file(creds, uri, fp, content_type=None, conn=None):
     if content_type is not None:
         k.content_type = content_type
 
-    k.set_contents_from_file(fp, encrypt_key=True)
+    storage_class = os.getenv('WALE_S3_STORAGE_CLASS', 'STANDARD')
+    k.set_contents_from_file(fp, encrypt_key=True,  headers=storage_class)
     return k
 
 


### PR DESCRIPTION
Add support for S3 storage class environment variable.  Adds feature requested in #215 

WALE_S3_STORAGE_CLASS, defaulting to STANDARD.  valid values: STANDARD | REDUCED_REDUNDANCY | GLACIER | STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING | DEEP_ARCHIVE
