### PR TITLE
docs: fix simple typo, arbitray -> arbitrary

### DIFF
--- a/wal_e/worker/upload.py
+++ b/wal_e/worker/upload.py
@@ -28,7 +28,7 @@ class WalUploader(object):
         self.blobstore = get_blobstore(layout)
 
     def __call__(self, segment):
-        # TODO :: Move arbitray path construction to StorageLayout Object
+        # TODO :: Move arbitrary path construction to StorageLayout Object
         url = '{0}/wal_{1}/{2}.lzo'.format(self.layout.prefix.rstrip('/'),
                                            storage.CURRENT_VERSION,
                                            segment.name)
@@ -98,7 +98,7 @@ class PartitionUploader(object):
 
             tf.flush()
 
-            # TODO :: Move arbitray path construction to StorageLayout Object
+            # TODO :: Move arbitrary path construction to StorageLayout Object
             url = '{0}/tar_partitions/part_{number:08d}.tar.lzo'.format(
                 self.backup_prefix.rstrip('/'), number=tpart.name)
 


### PR DESCRIPTION
There is a small typo in wal_e/worker/upload.py.

Should read `arbitrary` rather than `arbitray`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md