### PR TITLE
Extend exception handling to cover Python issue35415

### DIFF
--- a/wal_e/pep3143daemon/daemon.py
+++ b/wal_e/pep3143daemon/daemon.py
@@ -373,11 +373,11 @@ def parent_is_inet():
     :return: bool
     """
     result = False
-    sock = socket.fromfd(
-        sys.__stdin__.fileno(),
-        socket.AF_INET,
-        socket.SOCK_RAW)
     try:
+        sock = socket.fromfd(
+            sys.__stdin__.fileno(),
+            socket.AF_INET,
+            socket.SOCK_RAW)
         sock.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE)
         result = True
     except (OSError, socket.error) as err:


### PR DESCRIPTION
Due to this Python bug patch from 2018-12 (https://bugs.python.org/issue35415), Wal-e would have a spam on unhandled exceptions on the prefetch functionality, if run using a Python version that contains the aforementioned bug fix, which provides additional validation. This is potentially harmful since it aborts the rest of the wal-e logic for each of these prefetch children processes.

See the traceback:
```
Dec 18 11:35:16 ip-10-60-0-67 wal-e[415818]: wal_e.main   CRITICAL MSG: An unprocessed exception has avoided all error handling
                                                     DETAIL: Traceback (most recent call last):
                                                       File "/usr/local/lib/python3.10/dist-packages/wal_e/cmd.py", line 649, in main
                                                         res = backup_cxt.wal_restore(args.WAL_SEGMENT,
                                                       File "/usr/local/lib/python3.10/dist-packages/wal_e/operator/backup.py", line 314, in wal_restore
                                                         started = start_prefetches(seg, pd, prefetch_max)
                                                       File "/usr/local/lib/python3.10/dist-packages/wal_e/operator/backup.py", line 584, in start_prefetches
                                                         with daemon.DaemonContext(stderr=open(os.devnull, 'w')):
                                                       File "/usr/local/lib/python3.10/dist-packages/wal_e/pep3143daemon/daemon.py", line 116, in __init__
                                                         else detach_required()
                                                       File "/usr/local/lib/python3.10/dist-packages/wal_e/pep3143daemon/daemon.py", line 398, in detach_required
                                                         if parent_is_inet() or parent_is_init():
                                                       File "/usr/local/lib/python3.10/dist-packages/wal_e/pep3143daemon/daemon.py", line 376, in parent_is_inet
                                                         sock = socket.fromfd(
                                                       File "/usr/lib/python3.10/socket.py", line 546, in fromfd
                                                         return socket(family, type, proto, nfd)
                                                       File "/usr/lib/python3.10/socket.py", line 232, in __init__
                                                         _socket.socket.__init__(self, family, type, proto, fileno)
                                                     OSError: [Errno 88] Socket operation on non-socket
```

With this simple patch, we extend/cover the `socket.fromfd` with the same existing error handling (Checking for `errno.ENOTSOCK`) a step earlier in the pipeline.

